### PR TITLE
fix: search service graceful degradation on ES unavailability (#1235)

### DIFF
--- a/novaRewards/backend/services/searchService.js
+++ b/novaRewards/backend/services/searchService.js
@@ -10,7 +10,7 @@ const logger = require('../lib/logger');
  *  - Expose index/delete helpers for event-driven sync
  */
 
-const { Client } = require('@elastic/elasticsearch');
+const { Client, errors } = require('@elastic/elasticsearch');
 
 // ---------------------------------------------------------------------------
 // Client
@@ -42,6 +42,39 @@ const INDICES = {
   campaigns: 'nova_campaigns',
   users:     'nova_users',
 };
+
+// ---------------------------------------------------------------------------
+// Connectivity error guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the error represents a transient ES connectivity problem
+ * (node unreachable, no cluster members alive, etc.).  These should be handled
+ * gracefully rather than propagating a 500 to the caller.
+ *
+ * Actual query/mapping ResponseErrors (bad requests) are NOT connectivity
+ * errors and must still propagate so the caller can react appropriately.
+ */
+function isConnectivityError(err) {
+  if (!err) return false;
+  // @elastic/elasticsearch v8+ exposes error classes on the `errors` export.
+  if (errors) {
+    if (
+      err instanceof errors.ConnectionError ||
+      err instanceof errors.NoLivingConnectionsError ||
+      err instanceof errors.TimeoutError
+    ) {
+      return true;
+    }
+  }
+  // Fallback for environments where the class check fails: inspect the name.
+  const name = err.name || '';
+  return (
+    name === 'ConnectionError' ||
+    name === 'NoLivingConnectionsError' ||
+    name === 'TimeoutError'
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Index mappings
@@ -185,21 +218,53 @@ function userToDoc(user) {
 // ---------------------------------------------------------------------------
 
 async function indexReward(reward) {
-  await getClient().index({ index: INDICES.rewards, id: String(reward.id), document: rewardToDoc(reward) });
+  try {
+    await getClient().index({ index: INDICES.rewards, id: String(reward.id), document: rewardToDoc(reward) });
+  } catch (err) {
+    if (isConnectivityError(err)) {
+      logger.warn('[Search] ES unreachable — indexReward skipped:', err.message);
+      return;
+    }
+    throw err;
+  }
 }
 
 async function indexCampaign(campaign) {
-  await getClient().index({ index: INDICES.campaigns, id: String(campaign.id), document: campaignToDoc(campaign) });
+  try {
+    await getClient().index({ index: INDICES.campaigns, id: String(campaign.id), document: campaignToDoc(campaign) });
+  } catch (err) {
+    if (isConnectivityError(err)) {
+      logger.warn('[Search] ES unreachable — indexCampaign skipped:', err.message);
+      return;
+    }
+    throw err;
+  }
 }
 
 async function indexUser(user) {
-  await getClient().index({ index: INDICES.users, id: String(user.id), document: userToDoc(user) });
+  try {
+    await getClient().index({ index: INDICES.users, id: String(user.id), document: userToDoc(user) });
+  } catch (err) {
+    if (isConnectivityError(err)) {
+      logger.warn('[Search] ES unreachable — indexUser skipped:', err.message);
+      return;
+    }
+    throw err;
+  }
 }
 
 async function deleteDocument(entityType, id) {
   const index = INDICES[entityType];
   if (!index) throw new Error(`Unknown entity type: ${entityType}`);
-  await getClient().delete({ index, id: String(id) });
+  try {
+    await getClient().delete({ index, id: String(id) });
+  } catch (err) {
+    if (isConnectivityError(err)) {
+      logger.warn('[Search] ES unreachable — deleteDocument skipped:', err.message);
+      return;
+    }
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -217,6 +282,10 @@ async function deleteDocument(entityType, id) {
  *   limit?: number,
  * }} opts
  * @returns {Promise<{ hits: object[], total: number, facets: object, durationMs: number }>}
+ *
+ * When Elasticsearch is unreachable (ConnectionError / NoLivingConnectionsError),
+ * the function degrades gracefully: logs a warning and returns an empty result
+ * set rather than propagating an unhandled 500.
  */
 async function search({ q, entityType = 'all', filters = {}, page = 1, limit = 20 }) {
   const client = getClient();
@@ -261,27 +330,37 @@ async function search({ q, entityType = 'all', filters = {}, page = 1, limit = 2
   };
 
   const t0 = Date.now();
-  const response = await client.search({
-    index: indices,
-    from,
-    size: limit,
-    query: esQuery,
-    highlight: {
-      fields: {
-        name:        { number_of_fragments: 0 },
-        description: { number_of_fragments: 1, fragment_size: 150 },
-        email:       { number_of_fragments: 0 },
+  let response;
+  try {
+    response = await client.search({
+      index: indices,
+      from,
+      size: limit,
+      query: esQuery,
+      highlight: {
+        fields: {
+          name:        { number_of_fragments: 0 },
+          description: { number_of_fragments: 1, fragment_size: 150 },
+          email:       { number_of_fragments: 0 },
+        },
       },
-    },
-    aggs: {
-      by_type: {
-        terms: { field: '_index', size: 10 },
+      aggs: {
+        by_type: {
+          terms: { field: '_index', size: 10 },
+        },
+        active_count: {
+          filter: { term: { is_active: true } },
+        },
       },
-      active_count: {
-        filter: { term: { is_active: true } },
-      },
-    },
-  });
+    });
+  } catch (err) {
+    if (isConnectivityError(err)) {
+      logger.warn('[Search] ES unreachable — returning degraded result for search:', err.message);
+      return { hits: [], total: 0, facets: { byType: [], activeCount: null }, durationMs: Date.now() - t0 };
+    }
+    // ResponseError (bad query, mapping mismatch, etc.) propagates normally
+    throw err;
+  }
   const durationMs = Date.now() - t0;
 
   const hits = response.hits.hits.map((hit) => ({
@@ -316,6 +395,8 @@ async function search({ q, entityType = 'all', filters = {}, page = 1, limit = 2
  *
  * @param {{ prefix: string, entityType?: string, limit?: number }} opts
  * @returns {Promise<string[]>}
+ *
+ * Returns an empty array when Elasticsearch is unreachable.
  */
 async function suggest({ prefix, entityType = 'all', limit = 5 }) {
   const client = getClient();
@@ -324,22 +405,31 @@ async function suggest({ prefix, entityType = 'all', limit = 5 }) {
     ? Object.values(INDICES)
     : [INDICES[entityType]].filter(Boolean);
 
-  const response = await client.search({
-    index: indices,
-    suggest: {
-      nova_suggest: {
-        prefix,
-        completion: {
-          field: 'suggest',
-          size:  limit,
-          skip_duplicates: true,
-          fuzzy: { fuzziness: 1 },
+  let response;
+  try {
+    response = await client.search({
+      index: indices,
+      suggest: {
+        nova_suggest: {
+          prefix,
+          completion: {
+            field: 'suggest',
+            size:  limit,
+            skip_duplicates: true,
+            fuzzy: { fuzziness: 1 },
+          },
         },
       },
-    },
-    _source: false,
-    size: 0,
-  });
+      _source: false,
+      size: 0,
+    });
+  } catch (err) {
+    if (isConnectivityError(err)) {
+      logger.warn('[Search] ES unreachable — returning empty suggestions:', err.message);
+      return [];
+    }
+    throw err;
+  }
 
   const options = response.suggest?.nova_suggest?.[0]?.options ?? [];
   return [...new Set(options.map((o) => o.text))];
@@ -385,4 +475,9 @@ module.exports = {
   suggest,
   bulkIndex,
   INDICES,
+  isConnectivityError,
+  /** For testing only — resets the singleton so a fresh client is created on next call. */
+  _resetClient() { esClient = null; },
+  /** For testing only — directly sets the ES client singleton (bypasses real Client constructor). */
+  _setClient(client) { esClient = client; },
 };

--- a/novaRewards/backend/tests/searchService.test.js
+++ b/novaRewards/backend/tests/searchService.test.js
@@ -1,0 +1,201 @@
+'use strict';
+
+/**
+ * Unit tests for searchService.js — Elasticsearch graceful degradation (#1235).
+ *
+ * Strategy: use the service's exported `_setClient` helper to inject a mock
+ * ES client directly into the singleton, bypassing the need to intercept the
+ * `@elastic/elasticsearch` CJS module (which is unreliable in this vitest/Vite
+ * hybrid environment because third-party CJS packages are not inlined through
+ * Vite's transform pipeline by default, so vi.mock hoisting cannot intercept
+ * their require() calls from within the service).
+ *
+ * Covers:
+ *   1. search() returns { hits: [], total: 0 } when ES throws ConnectionError
+ *   2. search() returns { hits: [], total: 0 } when ES throws NoLivingConnectionsError
+ *   3. error is NOT thrown (degraded path) for connectivity errors
+ *   4. ResponseError (bad query) is still propagated — not swallowed
+ *   5. suggest() returns [] when ES is unreachable
+ *   6. search() returns real data when ES is reachable (happy path)
+ *   7. indexReward() silently continues when ES is unreachable
+ *   8. deleteDocument() silently continues when ES is unreachable
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Error class stubs — named to trigger the name-based fallback in
+// isConnectivityError() since instanceof checks across mock boundaries may
+// fail depending on how vitest loads the module.
+// ---------------------------------------------------------------------------
+
+class ConnectionError extends Error {
+  constructor(msg) { super(msg); this.name = 'ConnectionError'; }
+}
+class NoLivingConnectionsError extends Error {
+  constructor(msg) { super(msg); this.name = 'NoLivingConnectionsError'; }
+}
+class ResponseError extends Error {
+  constructor(msg) { super(msg); this.name = 'ResponseError'; this.statusCode = 400; }
+}
+
+// ---------------------------------------------------------------------------
+// Mock ES client methods as module-level fns so we can configure them per-test
+// ---------------------------------------------------------------------------
+
+const mockSearch = vi.fn();
+const mockIndex  = vi.fn();
+const mockDelete = vi.fn();
+
+// The mock client object injected via _setClient()
+const mockEsClient = {
+  search:  mockSearch,
+  index:   mockIndex,
+  delete:  mockDelete,
+  bulk:    vi.fn(),
+  indices: {
+    exists: vi.fn().mockResolvedValue(false),
+    create: vi.fn().mockResolvedValue({}),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Import the service module.
+// We use _setClient() to inject mockEsClient so that internal calls to
+// getClient() inside search(), suggest(), indexReward(), etc. return our mock.
+// ---------------------------------------------------------------------------
+
+import {
+  search,
+  suggest,
+  indexReward,
+  deleteDocument,
+  _setClient,
+  _resetClient,
+} from '../services/searchService.js';
+
+// ---------------------------------------------------------------------------
+// Helper: minimal ES search response
+// ---------------------------------------------------------------------------
+
+function fakeSearchResponse(hits = [], total = 0) {
+  return {
+    hits: {
+      hits:  hits.map((src) => ({ _index: 'nova_rewards', _score: 1, _source: src, highlight: {} })),
+      total: { value: total },
+    },
+    aggregations: {
+      by_type:     { buckets: [] },
+      active_count: { doc_count: 0 },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('searchService — graceful degradation (#1235)', () => {
+  beforeEach(() => {
+    // Inject the mock client so all internal getClient() calls return mockEsClient.
+    // This avoids unreliable vi.mock hoisting for third-party CJS modules.
+    _setClient(mockEsClient);
+    mockSearch.mockReset();
+    mockIndex.mockReset();
+    mockDelete.mockReset();
+  });
+
+  afterEach(() => {
+    // Reset the singleton so tests don't bleed into each other
+    _resetClient();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. ConnectionError → degraded result { hits: [], total: 0 }
+  // -------------------------------------------------------------------------
+  test('search() returns { hits: [], total: 0 } when ES throws ConnectionError', async () => {
+    mockSearch.mockRejectedValueOnce(new ConnectionError('ECONNREFUSED'));
+
+    const result = await search({ q: 'coffee' });
+
+    expect(result.hits).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.facets).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. NoLivingConnectionsError → degraded result
+  // -------------------------------------------------------------------------
+  test('search() returns { hits: [], total: 0 } when ES throws NoLivingConnectionsError', async () => {
+    mockSearch.mockRejectedValueOnce(new NoLivingConnectionsError('No living connections'));
+
+    const result = await search({ q: 'rewards' });
+
+    expect(result.hits).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Connectivity errors do NOT throw — they return the degraded shape
+  // -------------------------------------------------------------------------
+  test('search() does not throw on ConnectionError (returns degraded result)', async () => {
+    mockSearch.mockRejectedValueOnce(new ConnectionError('ECONNREFUSED'));
+
+    await expect(search({ q: 'test' })).resolves.toMatchObject({ hits: [], total: 0 });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. ResponseError (bad query) still propagates
+  // -------------------------------------------------------------------------
+  test('search() propagates ResponseError (bad query) without swallowing it', async () => {
+    mockSearch.mockRejectedValueOnce(new ResponseError('index_not_found_exception'));
+
+    await expect(search({ q: 'rewards' })).rejects.toThrow('index_not_found_exception');
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. suggest() returns [] when ES is unreachable
+  // -------------------------------------------------------------------------
+  test('suggest() returns [] when ES throws ConnectionError', async () => {
+    mockSearch.mockRejectedValueOnce(new ConnectionError('ECONNREFUSED'));
+
+    const result = await suggest({ prefix: 'cof' });
+
+    expect(result).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Happy path — real data returned when ES is healthy
+  // -------------------------------------------------------------------------
+  test('search() returns hits when ES responds normally', async () => {
+    const fakeHits = [{ id: 1, name: 'Coffee reward', is_active: true }];
+    mockSearch.mockResolvedValueOnce(fakeSearchResponse(fakeHits, 1));
+
+    const result = await search({ q: 'coffee' });
+
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0].name).toBe('Coffee reward');
+    expect(result.total).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. indexReward() degrades gracefully — resolves without throwing
+  // -------------------------------------------------------------------------
+  test('indexReward() resolves without throwing when ES is unreachable', async () => {
+    mockIndex.mockRejectedValueOnce(new ConnectionError('ECONNREFUSED'));
+
+    await expect(
+      indexReward({ id: 1, name: 'Test', description: '', cost: 10, stock: 5, is_active: true, created_at: new Date() })
+    ).resolves.toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. deleteDocument() degrades gracefully — resolves without throwing
+  // -------------------------------------------------------------------------
+  test('deleteDocument() resolves without throwing when ES is unreachable', async () => {
+    mockDelete.mockRejectedValueOnce(new ConnectionError('ECONNREFUSED'));
+
+    await expect(deleteDocument('rewards', 1)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Wraps all public search methods with connectivity-error handling so that a temporarily unreachable Elasticsearch cluster returns empty/degraded results instead of propagating unhandled 500s.

## Changes

- **`services/searchService.js`**
  - `isConnectivityError()` — identifies `ConnectionError`, `NoLivingConnectionsError`, `TimeoutError` from `@elastic/elasticsearch`
  - `search()` — catches connectivity errors, logs `warn`, returns `{ hits: [], total: 0, facets: {...}, durationMs }`
  - `suggest()` — returns `[]` on connectivity errors
  - `indexReward()`, `indexCampaign()`, `indexUser()`, `deleteDocument()` — resolve silently on connectivity errors
  - `ResponseError` (bad queries / mapping mismatch) still propagates normally
  - Added `_setClient()` test helper for reliable mock injection
- **`tests/searchService.test.js`** — 8 unit tests covering all acceptance criteria

## Acceptance Criteria

- [x] `searchRewards` returns `{ hits: [], total: 0 }` when ES is unreachable
- [x] Error is logged at `warn` level (not `error`) for transient connectivity issues
- [x] Unit test mocks ES client to throw `ConnectionError` and verifies degraded response
- [x] Actual `ResponseError` for bad queries still propagates normally
- [x] Existing search functionality unaffected when ES is reachable (happy-path test)

## Testing

```
npx vitest run tests/searchService.test.js
Test Files  1 passed (1)
Tests       8 passed (8)
Duration    ~500ms
```

Closes #1235