### PR TITLE
fix(security): harden authenticateMerchant middleware against timing attacks (closes #1231)

### DIFF
--- a/novaRewards/backend/middleware/authenticateMerchant.js
+++ b/novaRewards/backend/middleware/authenticateMerchant.js
@@ -1,23 +1,30 @@
 'use strict';
-const { createHash } = require('crypto');
-const { getMerchantByApiKeyHash } = require('../db/merchantRepository');
+const { createHash, timingSafeEqual } = require('crypto');
+const merchantRepo = require('../db/merchantRepository');
 
 /**
  * Middleware: validates the merchant API key from the x-api-key header.
- * Hashes the provided key and compares against the stored hash.
+ * Hashes the provided key and compares against the stored hash using timing-safe comparison.
  * Attaches the merchant record to req.merchant on success.
  */
 async function authenticateMerchant(req, res, next) {
   try {
     const apiKey = req.headers['x-api-key'];
-    if (!apiKey) {
+    if (!apiKey || typeof apiKey !== 'string') {
       return res.status(401).json({ success: false, error: 'unauthorized', message: 'x-api-key header is required' });
     }
 
     const apiKeyHash = createHash('sha256').update(apiKey).digest('hex');
-    const merchant = await getMerchantByApiKeyHash(apiKeyHash);
+    const merchant = await merchantRepo.getMerchantByApiKeyHash(apiKeyHash);
 
-    if (!merchant) {
+    if (!merchant || !merchant.api_key) {
+      return res.status(401).json({ success: false, error: 'unauthorized', message: 'Invalid API key' });
+    }
+
+    const computedBuffer = Buffer.from(apiKeyHash, 'utf8');
+    const storedBuffer = Buffer.from(merchant.api_key, 'utf8');
+
+    if (computedBuffer.length !== storedBuffer.length || !timingSafeEqual(computedBuffer, storedBuffer)) {
       return res.status(401).json({ success: false, error: 'unauthorized', message: 'Invalid API key' });
     }
 

--- a/novaRewards/backend/tests/authenticateMerchant.test.js
+++ b/novaRewards/backend/tests/authenticateMerchant.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const { createHash } = require('crypto');
+const merchantRepo = require('../db/merchantRepository');
+const { authenticateMerchant } = require('../middleware/authenticateMerchant');
+
+function mockReqRes(headers = {}) {
+  const req = { headers };
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('authenticateMerchant middleware', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 401 with unauthorized error when x-api-key header is missing', async () => {
+    const spy = vi.spyOn(merchantRepo, 'getMerchantByApiKeyHash');
+    const { req, res, next } = mockReqRes({});
+
+    await authenticateMerchant(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'unauthorized',
+      message: 'x-api-key header is required',
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 with unauthorized error when x-api-key header is empty string', async () => {
+    const { req, res, next } = mockReqRes({ 'x-api-key': '' });
+
+    await authenticateMerchant(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'unauthorized',
+      message: 'x-api-key header is required',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 with unauthorized error when merchant is not found in database', async () => {
+    const spy = vi.spyOn(merchantRepo, 'getMerchantByApiKeyHash').mockResolvedValue(null);
+
+    const validKey = 'nova_live_1234567890abcdef';
+    const { req, res, next } = mockReqRes({ 'x-api-key': validKey });
+
+    await authenticateMerchant(req, res, next);
+
+    const expectedHash = createHash('sha256').update(validKey).digest('hex');
+    expect(spy).toHaveBeenCalledWith(expectedHash);
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'unauthorized',
+      message: 'Invalid API key',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 with unauthorized error when stored hash does not match computed hash', async () => {
+    const validKey = 'nova_live_1234567890abcdef';
+    const differentHash = createHash('sha256').update('different_key').digest('hex');
+
+    vi.spyOn(merchantRepo, 'getMerchantByApiKeyHash').mockResolvedValue({
+      id: 42,
+      name: 'Acme Corp',
+      api_key: differentHash,
+    });
+
+    const { req, res, next } = mockReqRes({ 'x-api-key': validKey });
+
+    await authenticateMerchant(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'unauthorized',
+      message: 'Invalid API key',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when stored merchant object has missing api_key property', async () => {
+    vi.spyOn(merchantRepo, 'getMerchantByApiKeyHash').mockResolvedValue({
+      id: 42,
+      name: 'Acme Corp',
+    });
+
+    const { req, res, next } = mockReqRes({ 'x-api-key': 'nova_live_123' });
+
+    await authenticateMerchant(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'unauthorized',
+      message: 'Invalid API key',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('attaches merchant to req and calls next on valid API key', async () => {
+    const validKey = 'nova_live_secret_key_999';
+    const hash = createHash('sha256').update(validKey).digest('hex');
+    const mockMerchant = {
+      id: 10,
+      name: 'Super Merchant',
+      wallet_address: 'GAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      api_key: hash,
+    };
+
+    const spy = vi.spyOn(merchantRepo, 'getMerchantByApiKeyHash').mockResolvedValue(mockMerchant);
+
+    const { req, res, next } = mockReqRes({ 'x-api-key': validKey });
+
+    await authenticateMerchant(req, res, next);
+
+    expect(spy).toHaveBeenCalledWith(hash);
+    expect(req.merchant).toBe(mockMerchant);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it('passes uncaught repository errors to next(err)', async () => {
+    const dbError = new Error('Database connection failed');
+    vi.spyOn(merchantRepo, 'getMerchantByApiKeyHash').mockRejectedValue(dbError);
+
+    const { req, res, next } = mockReqRes({ 'x-api-key': 'some_key' });
+
+    await authenticateMerchant(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(dbError);
+  });
+});


### PR DESCRIPTION
## Summary
Hardens `authenticateMerchant` middleware against timing side-channel attacks when comparing API key SHA-256 hashes.

## Key Changes
- Uses `crypto.timingSafeEqual` with length matching check on byte buffers rather than JavaScript string equality (`===`).
- Adds validation for `x-api-key` header type and presence.
- Added comprehensive unit tests in `novaRewards/backend/tests/authenticateMerchant.test.js` covering:
  - Missing `x-api-key` header (401)
  - Empty `x-api-key` string (401)
  - Merchant not found in DB (401)
  - Invalid / mismatched API key hash (401)
  - Missing `api_key` field on record (401)
  - Valid key passes and attaches `req.merchant` (calls `next()`)
  - DB error propagation to `next(err)`

Closes #1231
