### PR TITLE
fix(backend): replace permissive CORS fallback in server.js with explicit allowlist (#1232)

### DIFF
--- a/novaRewards/.env.example
+++ b/novaRewards/.env.example
@@ -51,6 +51,10 @@ NODE_ENV=development
 # [REQUIRED in production]
 ALLOWED_ORIGIN=http://localhost:3000
 
+# Configurable CORS allowed origins (comma-separated list). Defaults to http://localhost:3000.
+# [OPTIONAL]
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+
 
 # =============================================================================
 # ── Stellar / Horizon ────────────────────────────────────────────────────────

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -40,10 +40,13 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Configure CORS based on environment
-const corsOptions =
-  process.env.NODE_ENV === "production" && process.env.ALLOWED_ORIGIN
-    ? { origin: process.env.ALLOWED_ORIGIN }
-    : {};
+const origins = (process.env.CORS_ALLOWED_ORIGINS || 'http://localhost:3000')
+  .split(',')
+  .map((s) => s.trim());
+
+const corsOptions = {
+  origin: origins,
+};
 
 const { compressionMiddleware } = require('./middleware/compressionMiddleware');
 

--- a/novaRewards/backend/tests/serverSetup.test.js
+++ b/novaRewards/backend/tests/serverSetup.test.js
@@ -68,11 +68,18 @@ describe('Express Server Setup & Middleware Integration', () => {
   });
 
   describe('CORS Behavior', () => {
-    it('allows requests and includes CORS headers in dev/test environment', async () => {
+    it('allows requests from listed origins and sets Access-Control-Allow-Origin header', async () => {
       const response = await request(app)
         .get('/health')
         .set('Origin', 'http://localhost:3000');
-      expect(response.headers['access-control-allow-origin']).toBe('*');
+      expect(response.headers['access-control-allow-origin']).toBe('http://localhost:3000');
+    });
+
+    it('rejects requests from unlisted origins without Access-Control-Allow-Origin header', async () => {
+      const response = await request(app)
+        .get('/health')
+        .set('Origin', 'http://unauthorized-origin.com');
+      expect(response.headers['access-control-allow-origin']).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Description
Resolves #1232.

Replaces the permissive CORS fallback `{}` (which allowed all origins in non-production environments) with a configurable `CORS_ALLOWED_ORIGINS` allowlist that safely defaults to `http://localhost:3000`.

## Changes
- **`novaRewards/backend/server.js`**: Parses `CORS_ALLOWED_ORIGINS` (comma-separated list) defaulting to `http://localhost:3000`, and passes the origin list array to `cors()`.
- **`novaRewards/backend/tests/serverSetup.test.js`**: Added test assertions verifying that requests with listed origins receive the proper `Access-Control-Allow-Origin` header and unlisted origins receive no allow origin header.
- **`novaRewards/.env.example`**: Documented `CORS_ALLOWED_ORIGINS` with default value `http://localhost:3000`.

## Verification
- Validated CORS allowlist behavior and origin matching with test cases.
- Verified unlisted origins do not get `Access-Control-Allow-Origin`.

/claim #1232
