### PR TITLE
fix(backend): require IDEMPOTENCY_HMAC_SECRET in production

### DIFF
--- a/novaRewards/backend/middleware/validateEnv.js
+++ b/novaRewards/backend/middleware/validateEnv.js
@@ -35,6 +35,8 @@ function validateEnv() {
     if (!process.env.ALLOWED_ORIGIN) missing.push('ALLOWED_ORIGIN');
     // REDIS_URL is required in production (sourced from Secrets Manager)
     if (!process.env.REDIS_URL) missing.push('REDIS_URL');
+    // IDEMPOTENCY_HMAC_SECRET signs idempotency keys; never fall back to weaker secrets
+    if (!process.env.IDEMPOTENCY_HMAC_SECRET) missing.push('IDEMPOTENCY_HMAC_SECRET');
   }
 
   if (process.env.BACKUP_ENABLED === 'true') {

--- a/novaRewards/backend/services/rewardIssuanceService.js
+++ b/novaRewards/backend/services/rewardIssuanceService.js
@@ -33,13 +33,10 @@ import { distributeRewards } from '../../blockchain/sendRewards';
 
 /**
  * The HMAC secret used to sign idempotency keys.
- * Use a dedicated env var so key-space is isolated from JWT/encryption secrets.
- * Falls back to a development-only placeholder — always set in production.
+ * Dedicated env var so key-space is isolated from JWT/encryption secrets.
+ * Required in production (enforced by validateEnv) — no fallback chain.
  */
-const IDEMPOTENCY_HMAC_SECRET =
-  process.env.IDEMPOTENCY_HMAC_SECRET ||
-  process.env.JWT_SECRET ||
-  'dev-insecure-idempotency-secret';
+const IDEMPOTENCY_HMAC_SECRET = process.env.IDEMPOTENCY_HMAC_SECRET;
 
 /**
  * Generates a collision-resistant HMAC-SHA256 idempotency key from a

--- a/novaRewards/backend/tests/validateEnv.test.js
+++ b/novaRewards/backend/tests/validateEnv.test.js
@@ -95,4 +95,29 @@ describe('validateEnv (Property 11)', () => {
 
     expect(() => validateEnv()).not.toThrow();
   });
+
+  test('throws when IDEMPOTENCY_HMAC_SECRET is missing in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ALLOWED_ORIGIN = 'https://example.com';
+    delete process.env.IDEMPOTENCY_HMAC_SECRET;
+
+    expect(() => validateEnv()).toThrow(expect.objectContaining({
+      message: expect.stringContaining('IDEMPOTENCY_HMAC_SECRET')
+    }));
+  });
+
+  test('passes when IDEMPOTENCY_HMAC_SECRET is set in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ALLOWED_ORIGIN = 'https://example.com';
+    process.env.IDEMPOTENCY_HMAC_SECRET = 'test-idempotency-secret';
+
+    expect(() => validateEnv()).not.toThrow();
+  });
+
+  test('passes when IDEMPOTENCY_HMAC_SECRET is missing in test', () => {
+    process.env.NODE_ENV = 'test';
+    delete process.env.IDEMPOTENCY_HMAC_SECRET;
+
+    expect(() => validateEnv()).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

`rewardIssuanceService.js` fell back to `JWT_SECRET` or a hardcoded dev string when `IDEMPOTENCY_HMAC_SECRET` was absent, letting a production deployment silently sign idempotency keys with a weaker or shared secret.

This change:
- Adds `IDEMPOTENCY_HMAC_SECRET` to the production-required list in `validateEnv.js`, so startup fails with a clear message when it is missing under `NODE_ENV=production`.
- Removes the fallback chain from `rewardIssuanceService.js` — the service now reads `process.env.IDEMPOTENCY_HMAC_SECRET` directly with no fallback.
- Adds `validateEnv.test.js` coverage confirming the variable is required in production but optional in test/development.

`.env.example` already documents the variable with a generation command.

## Test plan

- `npx vitest run tests/validateEnv.test.js` — all tests pass (including the 3 new production/test cases).
- `node novaRewards/scripts/check-env-example.js` — reports `.env.example` in sync with all env schemas.
- `npx eslint middleware/validateEnv.js services/rewardIssuanceService.js tests/validateEnv.test.js` — no issues.

Note: `tests/rewardIssuanceEngine.test.js` has 16 pre-existing failures from unrelated mock-state leakage between tests; they reproduce identically on `main` and are not touched by this change.

Closes #1236