### PR TITLE
[Smart Contracts] Add Unauthorized and NotInitialized error variants to vesting contract

### DIFF
--- a/contracts/fuzz/fuzz_targets/fuzz_vesting.rs
+++ b/contracts/fuzz/fuzz_targets/fuzz_vesting.rs
@@ -50,13 +50,14 @@ fuzz_target!(|data: &[u8]| {
     let beneficiary = Address::generate(&env);
 
     client.initialize(&admin);
-    client.fund_pool(&total_amount);
+    client.fund_pool(&admin, &total_amount);
 
     env.ledger().set_timestamp(initial_ts);
 
     // create_schedule rejects zero durations/amounts and timestamp-overflow
     // combinations — those rejections are correct behaviour, not crashes.
     let schedule_id = match client.try_create_schedule(
+        &admin,
         &beneficiary,
         &total_amount,
         &start_time,
@@ -77,7 +78,7 @@ fuzz_target!(|data: &[u8]| {
             .set_timestamp(env.ledger().timestamp().saturating_add(advance));
 
         if op[0] & 0x03 == 0 && !revoked {
-            if let Ok(Ok(r)) = client.try_revoke(&beneficiary, &schedule_id) {
+            if let Ok(Ok(r)) = client.try_revoke(&admin, &beneficiary, &schedule_id) {
                 assert!(r >= 0, "revoke returned a negative amount");
                 returned = r;
                 revoked = true;

--- a/contracts/integration_tests/tests/integration_test.rs
+++ b/contracts/integration_tests/tests/integration_test.rs
@@ -59,7 +59,7 @@ fn setup() -> Suite<'static> {
     let vest_id = env.register(VestingContract, ());
     let vesting = VestingContractClient::new(&env, &vest_id);
     vesting.initialize(&admin);
-    vesting.fund_pool(&1_000_000);
+    vesting.fund_pool(&admin, &1_000_000);
 
     Suite {
         env,
@@ -240,7 +240,7 @@ fn test_vesting_create_and_release() {
     // start=0, cliff=0, duration=1000, total=1000
     let sid = s
         .vesting
-        .create_schedule(&beneficiary, &1_000, &0, &0, &1_000);
+        .create_schedule(&s.admin, &beneficiary, &1_000, &0, &0, &1_000);
     s.env.ledger().set_timestamp(500);
 
     let released = s.vesting.claim_vested(&beneficiary, &sid);
@@ -258,7 +258,7 @@ fn test_vesting_full_release_after_duration() {
 
     let sid = s
         .vesting
-        .create_schedule(&beneficiary, &2_000, &0, &0, &1_000);
+        .create_schedule(&s.admin, &beneficiary, &2_000, &0, &0, &1_000);
     s.env.ledger().set_timestamp(1_000);
 
     let released = s.vesting.claim_vested(&beneficiary, &sid);
@@ -275,7 +275,7 @@ fn test_vesting_before_cliff_nothing_released() {
     // cliff at t=200 (start=0 + cliff_duration=200)
     let schedule = s
         .vesting
-        .create_schedule(&beneficiary, &1_000, &0, &200, &1_000);
+        .create_schedule(&s.admin, &beneficiary, &1_000, &0, &200, &1_000);
     s.env.ledger().set_timestamp(100); // before cliff
 
     let sched = s.vesting.get_schedule(&beneficiary, &schedule);
@@ -351,7 +351,7 @@ fn test_vesting_double_release_rejected() {
     let beneficiary = Address::generate(&s.env);
     let sid = s
         .vesting
-        .create_schedule(&beneficiary, &1_000, &0, &0, &1_000);
+        .create_schedule(&s.admin, &beneficiary, &1_000, &0, &0, &1_000);
     s.env.ledger().set_timestamp(1_000);
     s.vesting.claim_vested(&beneficiary, &sid);
     s.vesting.claim_vested(&beneficiary, &sid);
@@ -397,7 +397,9 @@ fn test_pool_deposit_and_vesting_release() {
     assert_eq!(s.pool.balance(), 10_000);
 
     // Admin creates vesting schedule for employee bonus.
-    let sid = s.vesting.create_schedule(&employee, &3_000, &0, &0, &600);
+    let sid = s
+        .vesting
+        .create_schedule(&s.admin, &employee, &3_000, &0, &0, &600);
     s.env.ledger().set_timestamp(600);
 
     // Employee releases fully vested tokens.

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -20,12 +20,12 @@
 //! ## Usage
 //! ```ignore
 //! client.initialize(&admin);
-//! client.fund_pool(&1_000_000);
-//! let id = client.create_schedule(&beneficiary, &100_000, &start, &cliff, &duration);
+//! client.fund_pool(&admin, &1_000_000);
+//! let id = client.create_schedule(&admin, &beneficiary, &100_000, &start, &cliff, &duration);
 //! // time passes …
 //! let claimed = client.claim_vested(&beneficiary, &id);
 //! // admin revokes remaining unvested tokens
-//! let returned = client.revoke(&beneficiary, &id);
+//! let returned = client.revoke(&admin, &beneficiary, &id);
 //! ```
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, Address, Env};
@@ -37,6 +37,10 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_sh
 pub enum Error {
     AlreadyInitialized = 1,
     ScheduleRevoked = 2,
+    /// Caller does not match the stored admin address.
+    Unauthorized = 3,
+    /// The contract has not been initialized yet (no admin set).
+    NotInitialized = 4,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -95,18 +99,44 @@ impl VestingContract {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
+    /// Verifies that `caller` is the stored admin and has authorized this call.
+    ///
+    /// Checks identity before invoking [`Address::require_auth`] so that a
+    /// mismatched caller yields a typed [`Error::Unauthorized`] instead of a
+    /// generic Soroban auth panic. Also guards against calling before
+    /// [`initialize`](VestingContract::initialize) has set an admin.
+    ///
+    /// # Errors
+    /// - [`Error::NotInitialized`] if no admin has been set yet.
+    /// - [`Error::Unauthorized`] if `caller` is not the stored admin.
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+        if *caller != Self::admin(env) {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+        Ok(())
+    }
+
     /// Adds tokens to the vesting pool used for future releases.
     ///
     /// # Parameters
+    /// - `caller` – Address invoking this call; must be the stored admin.
     /// - `amount` – Tokens to add to the pool (must be > 0).
     ///
     /// # Authorization
-    /// Requires admin authorization.
+    /// Requires `caller` to be the admin and to have authorized this call.
+    ///
+    /// # Errors
+    /// - [`Error::NotInitialized`] if the contract has not been initialized.
+    /// - [`Error::Unauthorized`] if `caller` is not the admin.
     ///
     /// # Panics
     /// - `"amount must be positive"` if `amount <= 0`.
-    pub fn fund_pool(env: Env, amount: i128) {
-        Self::admin(&env).require_auth();
+    pub fn fund_pool(env: Env, caller: Address, amount: i128) -> Result<(), Error> {
+        Self::require_admin(&env, &caller)?;
         assert!(amount > 0, "amount must be positive");
         let bal: i128 = env
             .storage()
@@ -116,6 +146,7 @@ impl VestingContract {
         env.storage()
             .instance()
             .set(&DataKey::PoolBalance, &(bal + amount));
+        Ok(())
     }
 
     /// Creates a vesting schedule for a beneficiary and returns its schedule id.
@@ -123,6 +154,7 @@ impl VestingContract {
     /// Schedule ids are per-beneficiary and start at `0`.
     ///
     /// # Parameters
+    /// - `caller` – Address invoking this call; must be the stored admin.
     /// - `beneficiary` – Address that will receive vested tokens.
     /// - `total_amount` – Total tokens to vest (must be > 0).
     /// - `start_time` – Unix timestamp (seconds) when vesting begins.
@@ -134,10 +166,14 @@ impl VestingContract {
     /// The new schedule id (`u32`) for this beneficiary.
     ///
     /// # Authorization
-    /// Requires admin authorization.
+    /// Requires `caller` to be the admin and to have authorized this call.
     ///
     /// # Events
     /// Emits `("vesting", "created")` with data `(beneficiary, id, total_amount, start_time, cliff_duration, total_duration)`.
+    ///
+    /// # Errors
+    /// - [`Error::NotInitialized`] if the contract has not been initialized.
+    /// - [`Error::Unauthorized`] if `caller` is not the admin.
     ///
     /// # Panics
     /// - `"total_duration must be > 0"` if `total_duration == 0`.
@@ -149,13 +185,14 @@ impl VestingContract {
     ///   [`claim_vested`](VestingContract::claim_vested) and permanently lock the schedule.
     pub fn create_schedule(
         env: Env,
+        caller: Address,
         beneficiary: Address,
         total_amount: i128,
         start_time: u64,
         cliff_duration: u64,
         total_duration: u64,
-    ) -> u32 {
-        Self::admin(&env).require_auth();
+    ) -> Result<u32, Error> {
+        Self::require_admin(&env, &caller)?;
         assert!(total_duration > 0, "total_duration must be > 0");
         assert!(total_amount > 0, "total_amount must be > 0");
         // Reject schedules whose vesting math would overflow later. Without these
@@ -201,7 +238,7 @@ impl VestingContract {
             (beneficiary, id, total_amount, start_time, cliff_duration, total_duration),
         );
 
-        id
+        Ok(id)
     }
 
     /// Computes the total vested amount for a schedule at a specific timestamp.
@@ -243,11 +280,17 @@ impl VestingContract {
     /// # Events
     /// Emits `("vesting", "claimed")` with data `(beneficiary: Address, amount: i128, timestamp: u64)`.
     ///
+    /// # Errors
+    /// - [`Error::NotInitialized`] if the contract has not been initialized.
+    ///
     /// # Panics
     /// - `"schedule not found"` if no schedule exists for the given beneficiary and id.
     /// - `"nothing to release"` if no new tokens have vested since the last release.
     /// - `"insufficient pool balance"` if the pool holds fewer tokens than the releasable amount.
-    pub fn claim_vested(env: Env, beneficiary: Address, schedule_id: u32) -> i128 {
+    pub fn claim_vested(env: Env, beneficiary: Address, schedule_id: u32) -> Result<i128, Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
         let key = DataKey::Schedule(beneficiary.clone(), schedule_id);
         let mut schedule: VestingSchedule = env
             .storage()
@@ -284,7 +327,7 @@ impl VestingContract {
             (beneficiary, releasable, now),
         );
 
-        releasable
+        Ok(releasable)
     }
 
     /// Revokes a vesting schedule, stopping future vesting and returning unvested
@@ -294,6 +337,7 @@ impl VestingContract {
     /// to collect any tokens that had already vested before this call.
     ///
     /// # Parameters
+    /// - `caller` – Address invoking this call; must be the stored admin.
     /// - `beneficiary` – Address that owns the schedule.
     /// - `schedule_id` – Id of the schedule to revoke.
     ///
@@ -301,16 +345,25 @@ impl VestingContract {
     /// The number of unvested tokens returned to the treasury pool.
     ///
     /// # Authorization
-    /// Requires admin authorization.
+    /// Requires `caller` to be the admin and to have authorized this call.
     ///
     /// # Events
     /// Emits `("vesting", "revoked")` with data `(beneficiary: Address, returned: i128, timestamp: u64)`.
     ///
+    /// # Errors
+    /// - [`Error::NotInitialized`] if the contract has not been initialized.
+    /// - [`Error::Unauthorized`] if `caller` is not the admin.
+    ///
     /// # Panics
     /// - `"schedule not found"` if no schedule exists for the given beneficiary and id.
     /// - `"already revoked"` if the schedule has already been revoked.
-    pub fn revoke(env: Env, beneficiary: Address, schedule_id: u32) -> i128 {
-        Self::admin(&env).require_auth();
+    pub fn revoke(
+        env: Env,
+        caller: Address,
+        beneficiary: Address,
+        schedule_id: u32,
+    ) -> Result<i128, Error> {
+        Self::require_admin(&env, &caller)?;
 
         let key = DataKey::Schedule(beneficiary.clone(), schedule_id);
         let mut schedule: VestingSchedule = env
@@ -349,7 +402,7 @@ impl VestingContract {
             (beneficiary, unvested, now),
         );
 
-        unvested
+        Ok(unvested)
     }
 
     /// Returns the stored schedule for a beneficiary and schedule id.
@@ -394,16 +447,16 @@ mod tests {
         let client = VestingContractClient::new(&env, &id);
         let admin = Address::generate(&env);
         client.initialize(&admin);
-        client.fund_pool(&1_000_000);
+        client.fund_pool(&admin, &1_000_000);
         (env, admin, client)
     }
 
     #[test]
     fn test_before_cliff_release_is_zero() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let beneficiary = Address::generate(&env);
         // start=100, cliff=200, duration=1000
-        let sid = client.create_schedule(&beneficiary, &1000, &100, &200, &1000);
+        let sid = client.create_schedule(&admin, &beneficiary, &1000, &100, &200, &1000);
         // set ledger time to 150 (before cliff at 300)
         env.ledger().set_timestamp(150);
         // vested = 0 because cliff not reached
@@ -415,10 +468,10 @@ mod tests {
 
     #[test]
     fn test_partial_linear_release() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let beneficiary = Address::generate(&env);
         // start=0, cliff=0, duration=1000, total=1000
-        let sid = client.create_schedule(&beneficiary, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &beneficiary, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(500);
         let released = client.claim_vested(&beneficiary, &sid);
         assert_eq!(released, 500);
@@ -426,9 +479,9 @@ mod tests {
 
     #[test]
     fn test_full_release_after_duration() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let beneficiary = Address::generate(&env);
-        let sid = client.create_schedule(&beneficiary, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &beneficiary, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(1000);
         let released = client.claim_vested(&beneficiary, &sid);
         assert_eq!(released, 1000);
@@ -437,9 +490,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "nothing to release")]
     fn test_double_release_blocked() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let beneficiary = Address::generate(&env);
-        let sid = client.create_schedule(&beneficiary, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &beneficiary, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(1000);
         client.claim_vested(&beneficiary, &sid);
         client.claim_vested(&beneficiary, &sid); // should panic
@@ -447,9 +500,9 @@ mod tests {
 
     #[test]
     fn test_release_emits_event() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let beneficiary = Address::generate(&env);
-        let sid = client.create_schedule(&beneficiary, &500, &0, &0, &500);
+        let sid = client.create_schedule(&admin, &beneficiary, &500, &0, &0, &500);
         env.ledger().set_timestamp(500);
         client.claim_vested(&beneficiary, &sid);
         let _ = env.events().all(); // drain; event emission verified via snapshot
@@ -462,14 +515,75 @@ mod tests {
         client.initialize(&admin);
     }
 
+    // ── typed auth / initialization errors ─────────────────────────────────────
+
+    #[test]
+    fn test_fund_pool_from_non_admin_returns_unauthorized() {
+        let (env, _admin, client) = setup();
+        let outsider = Address::generate(&env);
+        let err = client.try_fund_pool(&outsider, &500).unwrap_err().unwrap();
+        assert_eq!(err, Error::Unauthorized);
+    }
+
+    #[test]
+    fn test_create_schedule_from_non_admin_returns_unauthorized() {
+        let (env, _admin, client) = setup();
+        let outsider = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let err = client
+            .try_create_schedule(&outsider, &beneficiary, &1000, &0, &0, &1000)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, Error::Unauthorized);
+    }
+
+    #[test]
+    fn test_revoke_from_non_admin_returns_unauthorized() {
+        let (env, admin, client) = setup();
+        let outsider = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let sid = client.create_schedule(&admin, &beneficiary, &1000, &0, &0, &1000);
+        let err = client
+            .try_revoke(&outsider, &beneficiary, &sid)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, Error::Unauthorized);
+    }
+
+    #[test]
+    fn test_claim_vested_before_initialize_returns_not_initialized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(VestingContract, ());
+        let client = VestingContractClient::new(&env, &id);
+        let beneficiary = Address::generate(&env);
+        // no initialize() call — contract has no admin set yet
+        let err = client
+            .try_claim_vested(&beneficiary, &0)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, Error::NotInitialized);
+    }
+
+    #[test]
+    fn test_fund_pool_before_initialize_returns_not_initialized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(VestingContract, ());
+        let client = VestingContractClient::new(&env, &id);
+        let someone = Address::generate(&env);
+        let err = client.try_fund_pool(&someone, &100).unwrap_err().unwrap();
+        assert_eq!(err, Error::NotInitialized);
+    }
+
     // ── zero cliff / immediate full vest ──────────────────────────────────────
 
     #[test]
     fn test_zero_cliff_vesting_starts_immediately() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
         // cliff=0 means vesting starts at start_time with no delay
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(1);
         let released = client.claim_vested(&b, &sid);
         assert_eq!(released, 1); // 1/1000 of tokens vested
@@ -477,10 +591,10 @@ mod tests {
 
     #[test]
     fn test_immediate_full_vest_at_start() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
         // duration=1, cliff=0, elapsed>=duration → 100% vested immediately
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1);
         env.ledger().set_timestamp(1);
         let released = client.claim_vested(&b, &sid);
         assert_eq!(released, 1000);
@@ -490,13 +604,13 @@ mod tests {
 
     #[test]
     fn test_revoke_returns_unvested_to_pool() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
         // 1000 tokens, start=0, no cliff, duration=1000
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         // at t=400: 400 vested, 600 unvested
         env.ledger().set_timestamp(400);
-        let returned = client.revoke(&b, &sid);
+        let returned = client.revoke(&admin, &b, &sid);
         assert_eq!(returned, 600);
         // pool went from 1_000_000 down to 999_000 after create_schedule funded nothing
         // then revoke adds 600 back: 999_000 + 600 = 999_600
@@ -505,12 +619,12 @@ mod tests {
 
     #[test]
     fn test_revoke_allows_claiming_vested_portion() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(500);
         // revoke; 500 unvested returned to pool
-        client.revoke(&b, &sid);
+        client.revoke(&admin, &b, &sid);
         // beneficiary can still claim the 500 that were vested at revocation
         let claimed = client.claim_vested(&b, &sid);
         assert_eq!(claimed, 500);
@@ -518,11 +632,11 @@ mod tests {
 
     #[test]
     fn test_revoke_stops_further_vesting() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(300);
-        client.revoke(&b, &sid);
+        client.revoke(&admin, &b, &sid);
         // advance time well past full duration
         env.ledger().set_timestamp(9999);
         // vested amount is still capped at what was vested at revocation (300)
@@ -534,59 +648,59 @@ mod tests {
     #[test]
     #[should_panic(expected = "already revoked")]
     fn test_revoke_twice_panics() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(500);
-        client.revoke(&b, &sid);
-        client.revoke(&b, &sid); // should panic
+        client.revoke(&admin, &b, &sid);
+        client.revoke(&admin, &b, &sid); // should panic
     }
 
     #[test]
     #[should_panic(expected = "schedule not found")]
     fn test_revoke_nonexistent_schedule_panics() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        client.revoke(&b, &99);
+        client.revoke(&admin, &b, &99);
     }
 
     #[test]
     fn test_revoke_fully_vested_returns_zero() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         // fully vested before revoke
         env.ledger().set_timestamp(1000);
-        let returned = client.revoke(&b, &sid);
+        let returned = client.revoke(&admin, &b, &sid);
         assert_eq!(returned, 0); // nothing unvested to return
     }
 
     #[test]
     fn test_revoke_before_cliff_returns_all() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
         // cliff at 500; revoke at t=100 (before cliff)
-        let sid = client.create_schedule(&b, &1000, &0, &500, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &500, &1000);
         env.ledger().set_timestamp(100);
-        let returned = client.revoke(&b, &sid);
+        let returned = client.revoke(&admin, &b, &sid);
         assert_eq!(returned, 1000); // nothing vested yet, all returned
     }
 
     #[test]
     fn test_revoke_emits_event() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        let sid = client.create_schedule(&b, &1000, &0, &0, &1000);
+        let sid = client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         env.ledger().set_timestamp(500);
-        client.revoke(&b, &sid);
+        client.revoke(&admin, &b, &sid);
         let _ = env.events().all();
     }
 
     #[test]
     fn test_create_schedule_emits_vesting_created_event() {
-        let (env, _admin, client) = setup();
+        let (env, admin, client) = setup();
         let b = Address::generate(&env);
-        client.create_schedule(&b, &1000, &0, &0, &1000);
+        client.create_schedule(&admin, &b, &1000, &0, &0, &1000);
         let _ = env.events().all();
     }
 }

--- a/contracts/vesting/tests/vesting_tests.rs
+++ b/contracts/vesting/tests/vesting_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use vesting::Error;
 use vesting::VestingContract;
 use vesting::VestingContractClient;
 use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
@@ -11,7 +12,7 @@ fn setup() -> (Env, Address, VestingContractClient<'static>) {
     let client = VestingContractClient::new(&env, &id);
     let admin = Address::generate(&env);
     client.initialize(&admin);
-    client.fund_pool(&1_000_000);
+    client.fund_pool(&admin, &1_000_000);
     (env, admin, client)
 }
 
@@ -39,36 +40,44 @@ fn initialize_twice_panics() {
 
 #[test]
 fn fund_pool_increases_balance() {
-    let (_env, _admin, client) = setup();
+    let (_env, admin, client) = setup();
     assert_eq!(client.pool_balance(), 1_000_000);
-    client.fund_pool(&500_000);
+    client.fund_pool(&admin, &500_000);
     assert_eq!(client.pool_balance(), 1_500_000);
 }
 
 #[test]
 #[should_panic(expected = "amount must be positive")]
 fn fund_pool_zero_panics() {
-    let (_env, _admin, client) = setup();
-    client.fund_pool(&0);
+    let (_env, admin, client) = setup();
+    client.fund_pool(&admin, &0);
+}
+
+#[test]
+fn fund_pool_from_non_admin_returns_unauthorized() {
+    let (env, _admin, client) = setup();
+    let outsider = Address::generate(&env);
+    let err = client.try_fund_pool(&outsider, &500).unwrap_err().unwrap();
+    assert_eq!(err, Error::Unauthorized);
 }
 
 // ── create_schedule ───────────────────────────────────────────────────────────
 
 #[test]
 fn create_schedule_returns_sequential_ids() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let id0 = client.create_schedule(&b, &1_000, &0, &0, &1_000);
-    let id1 = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let id0 = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
+    let id1 = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
 }
 
 #[test]
 fn create_schedule_stores_correct_fields() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &5_000, &100, &200, &1_000);
+    let sid = client.create_schedule(&admin, &b, &5_000, &100, &200, &1_000);
     let s = client.get_schedule(&b, &sid);
     assert_eq!(s.total_amount, 5_000);
     assert_eq!(s.start_time, 100);
@@ -81,27 +90,39 @@ fn create_schedule_stores_correct_fields() {
 #[test]
 #[should_panic(expected = "total_duration must be > 0")]
 fn create_schedule_zero_duration_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    client.create_schedule(&b, &1_000, &0, &0, &0);
+    client.create_schedule(&admin, &b, &1_000, &0, &0, &0);
 }
 
 #[test]
 #[should_panic(expected = "total_amount must be > 0")]
 fn create_schedule_zero_amount_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    client.create_schedule(&b, &0, &0, &0, &1_000);
+    client.create_schedule(&admin, &b, &0, &0, &0, &1_000);
+}
+
+#[test]
+fn create_schedule_from_non_admin_returns_unauthorized() {
+    let (env, _admin, client) = setup();
+    let outsider = Address::generate(&env);
+    let b = Address::generate(&env);
+    let err = client
+        .try_create_schedule(&outsider, &b, &1_000, &0, &0, &1_000)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
 }
 
 // ── claim_vested ──────────────────────────────────────────────────────────────
 
 #[test]
 fn release_before_cliff_nothing_vested() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // cliff at start_time(100) + cliff_duration(200) = 300; ledger at 150
-    let sid = client.create_schedule(&b, &1_000, &100, &200, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &100, &200, &1_000);
     env.ledger().set_timestamp(150);
     let s = client.get_schedule(&b, &sid);
     assert_eq!(s.released, 0);
@@ -109,10 +130,10 @@ fn release_before_cliff_nothing_vested() {
 
 #[test]
 fn release_at_cliff_gives_proportional_amount() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // start=0, cliff=0, duration=1000, amount=1000
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(500);
     let released = client.claim_vested(&b, &sid);
     assert_eq!(released, 500);
@@ -121,9 +142,9 @@ fn release_at_cliff_gives_proportional_amount() {
 
 #[test]
 fn release_after_full_duration_gives_total() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(1_000);
     let released = client.claim_vested(&b, &sid);
     assert_eq!(released, 1_000);
@@ -131,9 +152,9 @@ fn release_after_full_duration_gives_total() {
 
 #[test]
 fn release_beyond_duration_gives_total() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(9_999);
     let released = client.claim_vested(&b, &sid);
     assert_eq!(released, 1_000);
@@ -141,9 +162,9 @@ fn release_beyond_duration_gives_total() {
 
 #[test]
 fn release_twice_gives_incremental_amounts() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(400);
     let r1 = client.claim_vested(&b, &sid);
     assert_eq!(r1, 400);
@@ -155,10 +176,10 @@ fn release_twice_gives_incremental_amounts() {
 #[test]
 #[should_panic(expected = "nothing to release")]
 fn release_when_nothing_vested_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // cliff at 500, ledger at 0
-    let sid = client.create_schedule(&b, &1_000, &0, &500, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &500, &1_000);
     env.ledger().set_timestamp(0);
     client.claim_vested(&b, &sid);
 }
@@ -166,10 +187,10 @@ fn release_when_nothing_vested_panics() {
 #[test]
 #[should_panic(expected = "nothing to release")]
 fn release_before_cliff_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // cliff at start(100) + cliff_duration(200) = 300; ledger at 150
-    let sid = client.create_schedule(&b, &1_000, &100, &200, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &100, &200, &1_000);
     env.ledger().set_timestamp(150);
     client.claim_vested(&b, &sid);
 }
@@ -177,9 +198,9 @@ fn release_before_cliff_panics() {
 #[test]
 #[should_panic(expected = "nothing to release")]
 fn double_release_at_same_time_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(1_000);
     client.claim_vested(&b, &sid);
     client.claim_vested(&b, &sid); // nothing left
@@ -204,9 +225,21 @@ fn release_when_pool_empty_panics() {
     client.initialize(&admin);
     // do NOT fund pool
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(1_000);
     client.claim_vested(&b, &sid);
+}
+
+#[test]
+fn claim_vested_before_initialize_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(VestingContract, ());
+    let client = VestingContractClient::new(&env, &id);
+    let b = Address::generate(&env);
+    // no initialize() call yet
+    let err = client.try_claim_vested(&b, &0).unwrap_err().unwrap();
+    assert_eq!(err, Error::NotInitialized);
 }
 
 // ── get_schedule ──────────────────────────────────────────────────────────────
@@ -223,11 +256,11 @@ fn get_nonexistent_schedule_panics() {
 
 #[test]
 fn multiple_beneficiaries_independent_schedules() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b1 = Address::generate(&env);
     let b2 = Address::generate(&env);
-    let s1 = client.create_schedule(&b1, &300, &0, &0, &300);
-    let s2 = client.create_schedule(&b2, &700, &0, &0, &700);
+    let s1 = client.create_schedule(&admin, &b1, &300, &0, &0, &300);
+    let s2 = client.create_schedule(&admin, &b2, &700, &0, &0, &700);
     env.ledger().set_timestamp(300);
     let r1 = client.claim_vested(&b1, &s1);
     assert_eq!(r1, 300);
@@ -240,9 +273,9 @@ fn multiple_beneficiaries_independent_schedules() {
 
 #[test]
 fn zero_cliff_vesting_starts_immediately() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(1);
     let released = client.claim_vested(&b, &sid);
     assert_eq!(released, 1);
@@ -250,10 +283,10 @@ fn zero_cliff_vesting_starts_immediately() {
 
 #[test]
 fn immediate_full_vest_with_duration_one() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // duration=1, elapsed>=1 → fully vested
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1);
     env.ledger().set_timestamp(1);
     let released = client.claim_vested(&b, &sid);
     assert_eq!(released, 1_000);
@@ -263,34 +296,34 @@ fn immediate_full_vest_with_duration_one() {
 
 #[test]
 fn revoke_returns_unvested_to_pool() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     // at t=400: 400 vested, 600 unvested
     env.ledger().set_timestamp(400);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 600);
     assert_eq!(client.pool_balance(), 1_000_600);
 }
 
 #[test]
 fn revoke_allows_claiming_vested_portion() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(500);
-    client.revoke(&b, &sid);
+    client.revoke(&admin, &b, &sid);
     let claimed = client.claim_vested(&b, &sid);
     assert_eq!(claimed, 500);
 }
 
 #[test]
 fn revoke_stops_further_vesting() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(300);
-    client.revoke(&b, &sid);
+    client.revoke(&admin, &b, &sid);
     // claim at a much later time — still capped at 300
     env.ledger().set_timestamp(9_999);
     let claimed = client.claim_vested(&b, &sid);
@@ -300,52 +333,62 @@ fn revoke_stops_further_vesting() {
 #[test]
 #[should_panic(expected = "already revoked")]
 fn revoke_twice_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(500);
-    client.revoke(&b, &sid);
-    client.revoke(&b, &sid);
+    client.revoke(&admin, &b, &sid);
+    client.revoke(&admin, &b, &sid);
 }
 
 #[test]
 #[should_panic(expected = "schedule not found")]
 fn revoke_nonexistent_schedule_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    client.revoke(&b, &99);
+    client.revoke(&admin, &b, &99);
+}
+
+#[test]
+fn revoke_from_non_admin_returns_unauthorized() {
+    let (env, admin, client) = setup();
+    let outsider = Address::generate(&env);
+    let b = Address::generate(&env);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
+    let err = client.try_revoke(&outsider, &b, &sid).unwrap_err().unwrap();
+    assert_eq!(err, Error::Unauthorized);
 }
 
 #[test]
 fn revoke_fully_vested_returns_zero() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     env.ledger().set_timestamp(1_000);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 0);
 }
 
 #[test]
 fn revoke_before_cliff_returns_all() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // cliff=500; revoke at t=100 (before cliff)
-    let sid = client.create_schedule(&b, &1_000, &0, &500, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &500, &1_000);
     env.ledger().set_timestamp(100);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 1_000);
 }
 
 #[test]
 fn claim_immediately_after_revoke_pays_exact_pro_rata() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // 10_000 tokens over 1_000s, no cliff
-    let sid = client.create_schedule(&b, &10_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &10_000, &0, &0, &1_000);
     // revoke at t=337 → exactly 3_370 vested pro-rata, 6_630 returned
     env.ledger().set_timestamp(337);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 6_630);
     // claim in the same ledger, immediately after revocation
     let claimed = client.claim_vested(&b, &sid);
@@ -360,12 +403,12 @@ fn claim_immediately_after_revoke_pays_exact_pro_rata() {
 
 #[test]
 fn claim_after_revoke_before_cliff_yields_nothing() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // cliff at 500; revoke at t=100 → nothing vested, nothing claimable ever
-    let sid = client.create_schedule(&b, &1_000, &0, &500, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &500, &1_000);
     env.ledger().set_timestamp(100);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 1_000);
     env.ledger().set_timestamp(10_000);
     assert!(client.try_claim_vested(&b, &sid).is_err());
@@ -373,16 +416,16 @@ fn claim_after_revoke_before_cliff_yields_nothing() {
 
 #[test]
 fn revoke_partial_then_claim_then_no_more() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    let sid = client.create_schedule(&b, &1_000, &0, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &0, &0, &1_000);
     // claim 200 first
     env.ledger().set_timestamp(200);
     let first = client.claim_vested(&b, &sid);
     assert_eq!(first, 200);
     // revoke at t=600: 600 vested total, 200 already released, 400 unvested returned
     env.ledger().set_timestamp(600);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 400);
     // claim remaining vested-but-not-released (600 - 200 = 400)
     let second = client.claim_vested(&b, &sid);
@@ -394,35 +437,35 @@ fn revoke_partial_then_claim_then_no_more() {
 #[test]
 #[should_panic(expected = "start_time + cliff_duration overflows u64")]
 fn create_schedule_cliff_end_overflow_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    client.create_schedule(&b, &1_000, &u64::MAX, &1, &1_000);
+    client.create_schedule(&admin, &b, &1_000, &u64::MAX, &1, &1_000);
 }
 
 #[test]
 #[should_panic(expected = "start_time + total_duration overflows u64")]
 fn create_schedule_vesting_end_overflow_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // cliff end (MAX-5 + 0) fits, vesting end (MAX-5 + 10) overflows
-    client.create_schedule(&b, &1_000, &(u64::MAX - 5), &0, &10);
+    client.create_schedule(&admin, &b, &1_000, &(u64::MAX - 5), &0, &10);
 }
 
 #[test]
 #[should_panic(expected = "total_amount * total_duration overflows i128")]
 fn create_schedule_pro_rata_numerator_overflow_panics() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
-    client.create_schedule(&b, &i128::MAX, &0, &0, &2);
+    client.create_schedule(&admin, &b, &i128::MAX, &0, &0, &2);
 }
 
 #[test]
 fn schedule_near_u64_boundary_vests_correctly() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     // vesting window ends exactly at u64::MAX — the largest valid schedule
     let start = u64::MAX - 1_000;
-    let sid = client.create_schedule(&b, &1_000, &start, &200, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &start, &200, &1_000);
     // before cliff (start + 200): nothing vested
     env.ledger().set_timestamp(start + 100);
     assert!(client.try_claim_vested(&b, &sid).is_err());
@@ -436,13 +479,13 @@ fn schedule_near_u64_boundary_vests_correctly() {
 
 #[test]
 fn revoke_near_u64_boundary_conserves_tokens() {
-    let (env, _admin, client) = setup();
+    let (env, admin, client) = setup();
     let b = Address::generate(&env);
     let start = u64::MAX - 1_000;
-    let sid = client.create_schedule(&b, &1_000, &start, &0, &1_000);
+    let sid = client.create_schedule(&admin, &b, &1_000, &start, &0, &1_000);
     // revoke at 40% through the window
     env.ledger().set_timestamp(start + 400);
-    let returned = client.revoke(&b, &sid);
+    let returned = client.revoke(&admin, &b, &sid);
     assert_eq!(returned, 600);
     env.ledger().set_timestamp(u64::MAX);
     assert_eq!(client.claim_vested(&b, &sid), 400);


### PR DESCRIPTION
## Summary

`VestingContract`'s admin-only entry points (`fund_pool`, `create_schedule`, `revoke`) called `admin.require_auth()` directly. When the caller wasn't the admin, this panicked with a generic Soroban auth trap instead of returning a typed error, and calling before `initialize()` would panic on an `unwrap()` of the missing admin key rather than reporting a clean "not initialized" state.

This adds two variants to the vesting contract's `Error` enum:

- `Error::Unauthorized` — caller is not the stored admin
- `Error::NotInitialized` — no admin has been set yet (`initialize()` not called)

and a `require_admin(env, caller)` helper used by `fund_pool`, `create_schedule`, and `revoke`. It checks initialization and caller identity *before* invoking `require_auth`, so a mismatched caller returns a typed `Err(Error::Unauthorized)` instead of trapping. This requires the caller's address as an explicit parameter on those three functions (previously they only trusted the stored admin's auth). `claim_vested` also now returns `Err(Error::NotInitialized)` up front instead of panicking inside a storage lookup when called before `initialize()`.

Closes #1229.

## Changes

- `contracts/vesting/src/lib.rs`: new `Error` variants, `require_admin` helper, `caller: Address` parameter added to `fund_pool`/`create_schedule`/`revoke`, explicit `NotInitialized` check in `claim_vested`, doc comments updated, plus new unit tests covering both error variants.
- `contracts/vesting/tests/vesting_tests.rs`: updated call sites for the new signatures, plus new integration tests for `Unauthorized` (fund_pool/create_schedule/revoke from a non-admin) and `NotInitialized` (claim_vested before initialize).
- `contracts/integration_tests/tests/integration_test.rs` and `contracts/fuzz/fuzz_targets/fuzz_vesting.rs`: updated the vesting call sites they exercise to match the new signatures.

## Test plan

- `cargo test -p vesting` — all 63 tests pass (22 unit tests in `src/lib.rs`, 41 integration tests in `tests/vesting_tests.rs`), including the new typed-error tests.
- `cargo check -p vesting` — compiles cleanly (only pre-existing, unrelated `Events::publish` deprecation warnings).
- Verified `contracts/integration_tests` and `contracts/fuzz` already fail to build on `main` for reasons unrelated to this change (a `#![no_std]`/panic-handler issue and missing crate deps in `integration_tests`, and a `soroban-sdk` version mismatch in the standalone fuzz workspace), so their vesting call sites were updated for consistency but could not be compiler-verified here.
