### PR TITLE
test(integration): wire Nova token into RewardPool.initialize

### DIFF
--- a/contracts/integration_tests/tests/integration_test.rs
+++ b/contracts/integration_tests/tests/integration_test.rs
@@ -45,7 +45,7 @@ fn setup() -> Suite<'static> {
 
     let pool_id = env.register(RewardPool, ());
     let pool = RewardPoolClient::new(&env, &pool_id);
-    pool.initialize(&admin);
+    pool.initialize(&admin, &token_id);
 
     let roles_id = env.register(AdminRolesContract, ());
     let admin_roles = AdminRolesContractClient::new(&env, &roles_id);
@@ -408,6 +408,46 @@ fn test_pool_deposit_and_vesting_release() {
 
     // Pool is independent — still holds merchant deposit.
     assert_eq!(s.pool.balance(), 10_000);
+}
+
+// ── 10. Pool ↔ token cross-contract balance verification (#1228) ─────────────
+//
+// `setup()` now wires the real Nova token address into `pool.initialize`, so
+// deposit/withdraw perform genuine cross-contract token transfers instead of
+// being silently skipped. These tests assert the actual token balances move.
+
+/// Depositing into the pool increases the pool contract's own Nova token
+/// balance by the deposited amount, and debits the depositor.
+#[test]
+fn test_pool_deposit_increases_token_balance() {
+    let s = setup();
+    let merchant = Address::generate(&s.env);
+
+    s.token.mint(&merchant, &5_000);
+    assert_eq!(s.token.balance(&s.pool.address), 0);
+
+    s.pool.deposit(&merchant, &5_000);
+
+    assert_eq!(s.token.balance(&s.pool.address), 5_000);
+    assert_eq!(s.token.balance(&merchant), 0);
+}
+
+/// Withdrawing from the pool increases the recipient's Nova token balance
+/// by the withdrawn amount (no fee configured by default) and debits the pool.
+#[test]
+fn test_pool_withdraw_increases_recipient_token_balance() {
+    let s = setup();
+    let merchant = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    s.token.mint(&merchant, &5_000);
+    s.pool.deposit(&merchant, &5_000);
+
+    assert_eq!(s.token.balance(&recipient), 0);
+    s.pool.withdraw(&recipient, &2_000);
+
+    assert_eq!(s.token.balance(&recipient), 2_000);
+    assert_eq!(s.token.balance(&s.pool.address), 3_000);
 }
 
 // ── Distribution integration tests (#1126) ───────────────────────────────────


### PR DESCRIPTION
## Summary
`setup()` in `contracts/integration_tests/tests/integration_test.rs` initialized `RewardPool` with only an admin (`pool.initialize(&admin)`), while the production `reward_pool` contract's `initialize` requires a token address (`initialize(admin, token)`). Because of this mismatch, the suite never exercised real cross-contract token transfers on `deposit`/`withdraw` — those calls only touched pool-internal accounting.

This PR wires the already-initialized `NovaToken` address into `pool.initialize`, and adds two tests that assert real token balances move:
- `test_pool_deposit_increases_token_balance` — pool contract's own Nova token balance increases (and the depositor's decreases) after `deposit`.
- `test_pool_withdraw_increases_recipient_token_balance` — recipient's Nova token balance increases (and the pool's decreases) after `withdraw`.

## Scope
Only `contracts/integration_tests/tests/integration_test.rs` is touched, per the issue's scope — no production contract changes.

## Test plan
- Added two new tests using `token.balance(...)` (not pool-internal accounting) to directly verify the cross-contract transfer effect described in the issue.
- **Note:** `cargo test -p integration_tests` currently cannot complete a full run in this repo state — it fails earlier during compilation of unrelated crates already broken on `main` (e.g. `reward_pool`'s duplicate/corrupted tail already tracked in #1225, and an unrelated `nova-rewards` `#[contracttype]`/`Option<StakeRecord>` compile error). Neither is touched or introduced by this change; I verified by building on a clean `main` checkout before making any edits. The new/edited code here follows the same call patterns (`Client::address`, `mint`, `balance`, `deposit`, `withdraw`) already used successfully elsewhere in this same test file, so it is expected to pass once those unrelated compile blockers are resolved.

Closes #1228