### PR TITLE
fix(frontend): unify token amount precision displays

### DIFF
--- a/novaRewards/frontend/__tests__/CampaignCard.test.js
+++ b/novaRewards/frontend/__tests__/CampaignCard.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CampaignCard from '../components/CampaignCard';
+import { formatTokenAmount } from '../lib/formatting';
 
 const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 const past   = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
@@ -40,8 +41,8 @@ describe('CampaignCard — active campaign', () => {
 
   it('renders reward rate', () => {
     render(<CampaignCard campaign={baseCampaign} onViewDetails={jest.fn()} />);
-    expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.getByText('NOVA')).toBeInTheDocument();
+    expect(screen.getByText(formatTokenAmount(5))).toBeInTheDocument();
+    expect(screen.getByText('/unit')).toBeInTheDocument();
   });
 
   it('shows Active status badge', () => {

--- a/novaRewards/frontend/__tests__/RewardCard.test.js
+++ b/novaRewards/frontend/__tests__/RewardCard.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import RewardCard from '../components/RewardCard';
+import { formatTokenAmount } from '../lib/formatting';
 
 const baseReward = {
   id: 1,
@@ -16,7 +17,7 @@ describe('RewardCard', () => {
   test('renders reward name and cost', () => {
     render(<RewardCard reward={baseReward} userPoints={200} onRedeem={jest.fn()} />);
     expect(screen.getByText('Coffee Voucher')).toBeInTheDocument();
-    expect(screen.getByText('100 pts')).toBeInTheDocument();
+    expect(screen.getByText(`${formatTokenAmount(100)} pts`)).toBeInTheDocument();
   });
 
   test('renders description when provided', () => {
@@ -47,7 +48,7 @@ describe('RewardCard', () => {
 
   test('shows points deficit message when user cannot afford', () => {
     render(<RewardCard reward={baseReward} userPoints={50} onRedeem={jest.fn()} />);
-    expect(screen.getByText('You need 50 more points')).toBeInTheDocument();
+    expect(screen.getByText(`You need ${formatTokenAmount(50)} more points`)).toBeInTheDocument();
   });
 
   test('shows out-of-stock badge and disables button when stock is 0', () => {

--- a/novaRewards/frontend/__tests__/RewardsLineChart.test.js
+++ b/novaRewards/frontend/__tests__/RewardsLineChart.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { formatTokenAmount } from '../../lib/formatting';
 
 // ── Recharts mock ──────────────────────────────────────────────────────────────
 // Recharts uses ResizeObserver and SVG APIs unavailable in jsdom.
@@ -114,7 +115,7 @@ describe('RewardsLineChart', () => {
       // Tooltip mock renders the content element with active=true
       expect(screen.getByRole('tooltip')).toBeInTheDocument();
       expect(screen.getByRole('tooltip')).toHaveTextContent('2024-01-15');
-      expect(screen.getByRole('tooltip')).toHaveTextContent('42');
+      expect(screen.getByRole('tooltip')).toHaveTextContent(formatTokenAmount(42));
       expect(screen.getByRole('tooltip')).toHaveTextContent('issuance');
     });
   });

--- a/novaRewards/frontend/components/CampaignCard.js
+++ b/novaRewards/frontend/components/CampaignCard.js
@@ -1,5 +1,7 @@
 'use client';
 
+import { formatTokenAmount } from '../lib/formatting';
+
 /**
  * CampaignCard — displays a single campaign in the discovery grid.
  *
@@ -163,7 +165,7 @@ export default function CampaignCard({ campaign, onViewDetails }) {
         >
           <span style={{ fontSize: '0.8rem', color: 'var(--muted)' }}>Reward rate</span>
           <span style={{ fontSize: '1.05rem', fontWeight: 800, color: 'var(--accent)' }}>
-            {rewardRate} NOVA<span style={{ fontSize: '0.75rem', fontWeight: 400, color: 'var(--muted)' }}>/unit</span>
+            {formatTokenAmount(rewardRate)} NOVA<span style={{ fontSize: '0.75rem', fontWeight: 400, color: 'var(--muted)' }}>/unit</span>
           </span>
         </div>
 

--- a/novaRewards/frontend/components/CampaignDetailModal.js
+++ b/novaRewards/frontend/components/CampaignDetailModal.js
@@ -1,7 +1,9 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
+import { formatTokenAmount } from '../lib/formatting';
 
 /**
  * CampaignDetailModal — full campaign details including eligibility rules.
@@ -185,7 +187,7 @@ export default function CampaignDetailModal({ campaign, onClose }) {
               gap: '0.75rem',
             }}
           >
-            <StatBox label="Reward Rate" value={`${rewardRate} NOVA/unit`} accent />
+            <StatBox label="Reward Rate" value={`${formatTokenAmount(rewardRate)} NOVA/unit`} accent />
             <StatBox label="Participants" value={participantCount > 0 ? participantCount.toLocaleString() : '—'} />
             <StatBox label="Start Date" value={start} />
             <StatBox label="End Date" value={end} />
@@ -256,9 +258,9 @@ export default function CampaignDetailModal({ campaign, onClose }) {
             Close
           </button>
           {status === 'active' && (
-            <a href="/dashboard" className="btn btn-primary" style={{ textDecoration: 'none' }}>
+            <Link href="/dashboard" className="btn btn-primary" style={{ textDecoration: 'none' }}>
               Participate Now →
-            </a>
+            </Link>
           )}
         </div>
       </div>

--- a/novaRewards/frontend/components/CampaignManager.js
+++ b/novaRewards/frontend/components/CampaignManager.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import api from '../lib/api';
+import { formatTokenAmount } from '../lib/formatting';
 import CampaignForm from './CampaignForm';
 import DataTable from './DataTable';
 import EmptyState from './EmptyState';
@@ -103,7 +104,7 @@ export default function CampaignManager({ merchantId, apiKey, onUpdate }) {
     {
       key: 'reward_rate',
       label: 'Rate',
-      render: (v) => (v != null ? `${v} NOVA/unit` : '—'),
+      render: (v) => (v != null ? `${formatTokenAmount(v)} NOVA/unit` : '—'),
     },
     {
       key: 'start_date',

--- a/novaRewards/frontend/components/IssueRewardForm.js
+++ b/novaRewards/frontend/components/IssueRewardForm.js
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { StrKey } from 'stellar-sdk';
 import api from '../lib/api';
+import { formatTokenAmount } from '../lib/formatting';
 import TransactionLink from './TransactionLink';
 
 /**
@@ -93,7 +94,7 @@ export default function IssueRewardForm({
         <option value="">Select a campaign…</option>
         {activeCampaigns.map((c) => (
           <option key={c.id} value={c.id}>
-            {c.name} ({c.reward_rate} NOVA/unit)
+            {c.name} ({formatTokenAmount(c.reward_rate)} NOVA/unit)
           </option>
         ))}
       </select>

--- a/novaRewards/frontend/components/PointsWidget.js
+++ b/novaRewards/frontend/components/PointsWidget.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Lottie from 'lottie-react';
 import api from '../lib/api';
 import { useWallet } from '../context/WalletContext';
+import { formatTokenAmount } from '../lib/formatting';
 import AnimatedCounter from './ui/AnimatedCounter';
 import counterAnimationData from '../public/points-counter-increment.json';
 import styles from '../styles/PointsWidget.module.css';
@@ -82,7 +83,7 @@ export default function PointsWidget() {
       <div className={styles.label}>Nova Points</div>
       <div className={styles.balanceWrapper}>
         <div className={styles.balanceWithAnimation}>
-        <AnimatedCounter value={balance} className={styles.balance} />
+        <AnimatedCounter value={balance} format={formatTokenAmount} className={styles.balance} />
           {showCounterAnimation && (
             <div className={styles.lottieOverlay}>
               <Lottie animationData={counterAnimationData} loop={false} />
@@ -91,7 +92,7 @@ export default function PointsWidget() {
         </div>
         {showDelta && delta !== 0 && (
           <div className={`${styles.delta} ${delta > 0 ? styles.positive : styles.negative}`}>
-            {delta > 0 ? `+${delta}` : delta}
+            {delta > 0 ? `+${formatTokenAmount(delta)}` : formatTokenAmount(delta)}
           </div>
         )}
       </div>

--- a/novaRewards/frontend/components/RedemptionCatalogue.js
+++ b/novaRewards/frontend/components/RedemptionCatalogue.js
@@ -7,6 +7,7 @@ import api from '../lib/api';
 import { signAndSubmit } from '../lib/freighter';
 import { useAuth } from '../context/AuthContext';
 import { useWallet } from '../context/WalletContext';
+import { formatTokenAmount } from '../lib/formatting';
 import { useToast } from './Toast';
 import RewardCard from './RewardCard';
 import RedemptionModal from './RedemptionModal';
@@ -214,7 +215,7 @@ export default function RedemptionCatalogue() {
         <div>
           <h1>Redeem Rewards</h1>
           <p className="redemption-subtitle">
-            You have <strong>{userPoints.toLocaleString()} points</strong> available
+            You have <strong>{formatTokenAmount(userPoints)} points</strong> available
           </p>
         </div>
       </div>

--- a/novaRewards/frontend/components/RedemptionFlow.js
+++ b/novaRewards/frontend/components/RedemptionFlow.js
@@ -115,7 +115,7 @@ export default function RedemptionFlow({ walletAddress, onSuccess }) {
                 onClick={() => { setSelectedCampaign(c); setStep(STEPS.AMOUNT); }}
               >
                 <span className="campaign-name">{c.name}</span>
-                <span className="campaign-rate">Rate: {c.reward_rate} NOVA / perk</span>
+                <span className="campaign-rate">Rate: {formatTokenAmount(c.reward_rate)} NOVA / perk</span>
               </button>
             </li>
           ))}
@@ -167,7 +167,7 @@ export default function RedemptionFlow({ walletAddress, onSuccess }) {
           <dt>Campaign</dt><dd>{selectedCampaign.name}</dd>
           <dt>Tokens to burn</dt><dd>{formatTokenAmount(amount)} NOVA</dd>
           <dt>Perk value received</dt><dd>{perkValue}</dd>
-          <dt>Exchange rate</dt><dd>{selectedCampaign.reward_rate} per NOVA</dd>
+          <dt>Exchange rate</dt><dd>{formatTokenAmount(selectedCampaign.reward_rate)} per NOVA</dd>
         </dl>
         <div className="flow-actions">
           <button className="btn btn-secondary" onClick={() => setStep(STEPS.AMOUNT)}>Back</button>

--- a/novaRewards/frontend/components/RedemptionModal.js
+++ b/novaRewards/frontend/components/RedemptionModal.js
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Image from 'next/image';
+import { formatTokenAmount } from '../lib/formatting';
 
 /**
  * Multi-step redemption modal:
@@ -98,15 +99,15 @@ export default function RedemptionModal({
             <div className="redemption-points">
               <div className="points-row">
                 <span className="points-label">Your Points</span>
-                <span className="points-value">{currentPoints.toLocaleString()}</span>
+                <span className="points-value">{formatTokenAmount(currentPoints)}</span>
               </div>
               <div className="points-row points-deduction">
                 <span className="points-label">Cost ({amount} × {reward.cost})</span>
-                <span className="points-value">−{totalCost.toLocaleString()}</span>
+                <span className="points-value">−{formatTokenAmount(totalCost)}</span>
               </div>
               <div className="points-row points-total">
                 <span className="points-label">Points After</span>
-                <span className="points-value">{pointsAfter.toLocaleString()}</span>
+                <span className="points-value">{formatTokenAmount(pointsAfter)}</span>
               </div>
             </div>
 

--- a/novaRewards/frontend/components/ReferralLink.js
+++ b/novaRewards/frontend/components/ReferralLink.js
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useEffect } from 'react';
 import api from '../lib/api';
+import { formatTokenAmount } from '../lib/formatting';
 import { withFeatureFlag, FLAGS } from '../lib/featureFlags';
 import CopyButton from './ui/CopyButton';
 
@@ -110,7 +111,7 @@ function ReferralLink({ userId }) {
         </div>
         <div className="stat-pill">
           <span className="stat-label">Tokens Earned:</span>
-          <span className="stat-value">{referralData.pointsEarned} NOVA</span>
+          <span className="stat-value">{formatTokenAmount(referralData.pointsEarned)} NOVA</span>
         </div>
       </div>
 

--- a/novaRewards/frontend/components/RewardCard.js
+++ b/novaRewards/frontend/components/RewardCard.js
@@ -1,5 +1,7 @@
 'use client';
 
+import { formatTokenAmount } from '../lib/formatting';
+
 /**
  * Individual reward card component.
  * Displays reward image, name, point cost, stock status, and redeem button.
@@ -39,7 +41,7 @@ export default function RewardCard({
         <div className="reward-meta">
           <div className="reward-cost">
             <span className="reward-cost-label">Cost:</span>
-            <span className="reward-cost-value">{reward.cost} pts</span>
+            <span className="reward-cost-value">{formatTokenAmount(reward.cost)} pts</span>
           </div>
           
           {reward.stock !== null && (
@@ -54,7 +56,7 @@ export default function RewardCard({
 
         {!canAfford && inStock && (
           <p className="reward-error">
-            You need {reward.cost - userPoints} more points
+            You need {formatTokenAmount(reward.cost - userPoints)} more points
           </p>
         )}
       </div>

--- a/novaRewards/frontend/components/StellarDropModal.js
+++ b/novaRewards/frontend/components/StellarDropModal.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
 import api from '../lib/api';
 import confetti from 'canvas-confetti';
+import { formatTokenAmount } from '../lib/formatting';
 
 /**
  * StellarDropModal - Displays eligible drops and handles claiming
@@ -275,7 +276,7 @@ const StellarDropModal = forwardRef(({ onClaimSuccess, onModalClose }, ref) => {
               Successfully Claimed!
             </h2>
             <p style={{ fontSize: '1.25rem', marginBottom: '0.5rem' }}>
-              You received <strong>{claimedAmount} NOVA</strong> tokens
+              You received <strong>{formatTokenAmount(claimedAmount)} NOVA</strong> tokens
             </p>
             <p style={{ color: '#4b5563' }}>
               The tokens have been added to your balance
@@ -297,7 +298,7 @@ const StellarDropModal = forwardRef(({ onClaimSuccess, onModalClose }, ref) => {
                 Stellar Drop Available!
               </h2>
               <p style={{ color: '#4b5563' }}>
-                You've qualified for a special reward
+                You&apos;ve qualified for a special reward
               </p>
             </div>
 
@@ -313,7 +314,7 @@ const StellarDropModal = forwardRef(({ onClaimSuccess, onModalClose }, ref) => {
                   Token Amount
                 </div>
                 <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#7c3aed' }}>
-                  {drop?.tokenAmount} NOVA
+                  {formatTokenAmount(drop?.tokenAmount)} NOVA
                 </div>
               </div>
 

--- a/novaRewards/frontend/components/analytics/SummaryCards.js
+++ b/novaRewards/frontend/components/analytics/SummaryCards.js
@@ -1,5 +1,6 @@
 'use client';
 
+import { formatTokenAmount } from '../../lib/formatting';
 import AnimatedCounter from '../ui/AnimatedCounter';
 
 /**
@@ -13,7 +14,7 @@ export default function SummaryCards({ summary }) {
     { key: 'totalRevenue',   label: 'Total Revenue',   icon: '💰', fmt: (v) => `$${Math.round(v).toLocaleString()}` },
     { key: 'activeUsers',    label: 'Active Users',    icon: '👥', fmt: (v) => Math.round(v).toLocaleString() },
     { key: 'conversionRate', label: 'Conversion Rate', icon: '📈', fmt: (v) => `${v.toFixed(1)}%` },
-    { key: 'rewardsIssued',  label: 'Rewards Issued',  icon: '🎁', fmt: (v) => Math.round(v).toLocaleString() },
+    { key: 'rewardsIssued',  label: 'Rewards Issued',  icon: '🎁', fmt: formatTokenAmount },
   ];
 
   return (

--- a/novaRewards/frontend/components/charts/RedemptionDonutChart.js
+++ b/novaRewards/frontend/components/charts/RedemptionDonutChart.js
@@ -1,5 +1,6 @@
 'use client';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { formatTokenAmount } from '../../lib/formatting';
 import { useChartTheme } from '../analytics/useChartTheme';
 import ChartEmptyState from './ChartEmptyState';
 
@@ -33,7 +34,7 @@ export default function RedemptionDonutChart({ data = [], loading = false, error
         </Pie>
         <Tooltip
           contentStyle={{ background: tooltip.bg, border: `1px solid ${tooltip.border}`, color: tooltip.color }}
-          formatter={(value) => [value.toLocaleString(), '']}
+          formatter={(value) => [formatTokenAmount(value), '']}
         />
         <Legend
           wrapperStyle={{ color: text, fontSize: 12 }}

--- a/novaRewards/frontend/components/charts/RewardsLineChart.js
+++ b/novaRewards/frontend/components/charts/RewardsLineChart.js
@@ -5,6 +5,7 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, Legend, Brush,
 } from 'recharts';
+import { formatTokenAmount } from '../../lib/formatting';
 import { useChartTheme } from '../analytics/useChartTheme';
 import ChartEmptyState from './ChartEmptyState';
 
@@ -25,7 +26,7 @@ function CustomTooltip({ active, payload, label }) {
       <p className="font-semibold mb-1">{label}</p>
       {payload.map((entry) => (
         <p key={entry.dataKey} style={{ color: entry.color }}>
-          {entry.name}: <strong>{entry.value?.toLocaleString()}</strong>
+          {entry.name}: <strong>{formatTokenAmount(entry.value)}</strong>
         </p>
       ))}
       {payload[0]?.payload?.type && (

--- a/novaRewards/frontend/components/merchant/CampaignList.js
+++ b/novaRewards/frontend/components/merchant/CampaignList.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import { formatTokenAmount } from '../../lib/formatting';
 import EmptyState from '../EmptyState';
 import DataTable from '../DataTable';
 
@@ -109,7 +110,7 @@ export default function CampaignList({ campaigns, loading, onPause, onResume }) 
     {
       key: 'rewardRate',
       label: 'Rate',
-      render: (v) => (v != null ? `${v} NOVA/unit` : '—'),
+      render: (v) => (v != null ? `${formatTokenAmount(v)} NOVA/unit` : '—'),
     },
     {
       key: 'endDate',

--- a/novaRewards/frontend/components/navigation/MobileDrawer.tsx
+++ b/novaRewards/frontend/components/navigation/MobileDrawer.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { X, Wallet, Star } from 'lucide-react';
 import { useWalletStore } from '../../store/walletStore';
+import { formatTokenAmount } from '../../lib/formatting';
 import { truncateAddress } from '../../lib/truncateAddress';
 import type { NavItem } from './Navbar';
 
@@ -121,7 +122,7 @@ export default function MobileDrawer({ isOpen, onClose, items }: MobileDrawerPro
                 {truncateAddress(publicKey)}
               </p>
               <p className="text-sm font-bold text-primary-600 dark:text-primary-400 mb-3">
-                {parseFloat(balance).toLocaleString()} NOVA
+                {formatTokenAmount(balance)} NOVA
               </p>
               <button
                 onClick={() => { disconnect(); onClose(); }}

--- a/novaRewards/frontend/components/referral/ReferralStatsWidget.tsx
+++ b/novaRewards/frontend/components/referral/ReferralStatsWidget.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useReferral } from '../../hooks/useReferral';
+import { formatTokenAmount } from '../../lib/formatting';
 
 interface ReferralStatsWidgetProps {
   userId: string | number | null | undefined;
@@ -107,7 +108,7 @@ export function ReferralStatsWidget({ userId, className = '' }: ReferralStatsWid
         />
         <StatItem
           label="Tokens earned"
-          value={`${stats?.tokensEarned ?? 0} NOVA`}
+          value={`${formatTokenAmount(stats?.tokensEarned ?? 0)} NOVA`}
           accent="text-violet-600 dark:text-violet-400"
           icon={
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/novaRewards/frontend/pages/merchant.js
+++ b/novaRewards/frontend/pages/merchant.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import CampaignForm from "../components/CampaignForm";
 import IssueRewardForm from "../components/IssueRewardForm";
@@ -133,8 +134,8 @@ export default function MerchantDashboard() {
       <nav className="nav">
         <span className="nav-brand">⭐ NovaRewards</span>
         <div className="nav-links">
-          <a href="/">Customer Portal</a>
-          <a href="/monitoring">Monitoring</a>
+          <Link href="/">Customer Portal</Link>
+          <Link href="/monitoring">Monitoring</Link>
         </div>
       </nav>
 
@@ -384,7 +385,7 @@ export default function MerchantDashboard() {
                             return (
                               <tr key={c.id}>
                                 <td>{c.name}</td>
-                                <td>{c.reward_rate} NOVA/unit</td>
+                                <td>{formatTokenAmount(c.reward_rate)} NOVA/unit</td>
                                 <td>{c.start_date?.slice(0, 10)}</td>
                                 <td>{c.end_date?.slice(0, 10)}</td>
                                 <td>


### PR DESCRIPTION
## Summary
- route remaining NOVA and points displays through the shared `formatTokenAmount()` utility
- update wallet, referral, redemption, campaign, and chart surfaces that were still using ad hoc formatting
- align affected frontend tests with the shared token formatting behavior

## Test plan
- [x] run `..\node_modules\.bin\jest.cmd --config .\jest.config.js --runInBand --testMatch "**/formatting.test.ts"`
- [x] run `..\node_modules\.bin\eslint.cmd` on touched frontend files
- [ ] broader component test files still hit pre-existing harness issues in this repo (`next/jest` root detection, broken mock paths, and React test runtime mismatches)