### PR TITLE
fix(reward-issuance): DLQ integration tests + unblock worker load/persist bugs

### DIFF
--- a/novaRewards/backend/jobs/queues.js
+++ b/novaRewards/backend/jobs/queues.js
@@ -32,8 +32,16 @@ const rewardIssuanceQueue = new Queue('reward-issuance', {
 });
 
 // ── DLQ Event Handler ─────────────────────────────────────────────
-// Persist permanently failed jobs to DB + Prometheus before removing from Redis
-rewardIssuanceQueue.on('failed', async (job, err) => {
+// Persist permanently failed jobs to DB + Prometheus before removing from Redis.
+//
+// NOTE: a plain BullMQ `Queue` instance never locally emits job-lifecycle
+// events ('failed'/'completed') — only `Worker` and `QueueEvents` do. The
+// `.on('failed', ...)` registration below is a no-op against real Redis, so
+// rewardIssuanceWorker.js's `worker.on('failed', ...)` handler (which fires
+// for real) calls this function directly. It's kept here — and still
+// registered on the queue — as the single source of truth for the
+// persistence logic and to preserve existing test coverage.
+async function handleRewardIssuanceFailure(job, err) {
   const maxAttempts = job.opts?.attempts ?? 3;
   if (job.attemptsMade < maxAttempts) {
     return; // Will be retried, not DLQ yet
@@ -66,7 +74,9 @@ rewardIssuanceQueue.on('failed', async (job, err) => {
     });
     // Do NOT remove job from queue so it doesn't disappear silently
   }
-});
+}
+
+rewardIssuanceQueue.on('failed', handleRewardIssuanceFailure);
 
 const transactionSubmissionQueue = new Queue('transaction-submission', {
   connection: redisConfig,
@@ -140,5 +150,6 @@ module.exports = {
   rewardDistributionQueue,
   serverAdapter,
   novaRewardDlqTotal,
+  handleRewardIssuanceFailure,
   shutdownQueues,
 };

--- a/novaRewards/backend/jobs/rewardIssuanceWorker.js
+++ b/novaRewards/backend/jobs/rewardIssuanceWorker.js
@@ -10,7 +10,8 @@
 
 const { Worker, Queue } = require('bullmq');
 const { processRewardIssuance } = require('../services/rewardIssuanceService');
-const rewardIssuanceRepository = require('../repositories/rewardIssuanceRepository');
+const rewardIssuanceRepository = require('../db/rewardIssuanceRepository');
+const { handleRewardIssuanceFailure } = require('./queues');
 const logger = require('../lib/logger');
 
 /** Maximum milliseconds to wait for the worker + DLQ to close cleanly. */
@@ -55,6 +56,11 @@ worker.on('failed', async (job, err) => {
       error: err.message,
     });
     await rewardDLQ.add('dead-letter', { ...job.data, failedReason: err.message });
+
+    // Persist to reward_issuance_failures + increment the Prometheus counter.
+    // This is the event that actually fires in production — see the NOTE on
+    // handleRewardIssuanceFailure in queues.js.
+    await handleRewardIssuanceFailure(job, err);
   }
 });
 

--- a/novaRewards/backend/services/rewardIssuanceService.js
+++ b/novaRewards/backend/services/rewardIssuanceService.js
@@ -16,16 +16,16 @@
  */
 
 import crypto from 'crypto';
-import { rewardIssuanceQueue } from '../jobs/queues';
+import { rewardIssuanceQueue } from '../jobs/queues.js';
 import {
   createIssuance,
   getIssuanceByKey,
   markConfirmed,
   markFailed,
   incrementAttempts,
-} from '../db/rewardIssuanceRepository';
-import { getActiveCampaign } from '../db/campaignRepository';
-import { distributeRewards } from '../../blockchain/sendRewards';
+} from '../db/rewardIssuanceRepository.js';
+import { getActiveCampaign } from '../db/campaignRepository.js';
+import { distributeRewards } from '../../blockchain/sendRewards.js';
 
 // ---------------------------------------------------------------------------
 // Idempotency key generation

--- a/novaRewards/backend/tests/rewardIssuanceWorkerDlq.test.js
+++ b/novaRewards/backend/tests/rewardIssuanceWorkerDlq.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+/**
+ * Integration tests: reward-issuance DLQ persistence path.
+ *
+ * Exercises the real BullMQ Worker + Queue against a real Redis instance and
+ * the real `reward_issuance_failures` table against a real Postgres
+ * instance — nothing here is mocked except `processRewardIssuance` (which
+ * talks to Stellar).
+ *
+ * Requires the docker-compose test services:
+ *   docker-compose -f docker-compose.test.yml up -d
+ * ...and the `reward_issuance_failures` table (schema in
+ * migrations/20260717000001_create_reward_issuance_failures.js) already
+ * present in the target database — this repo doesn't currently have a
+ * wired-up runner for that migration file, so create it manually against
+ * your test DB if it's missing.
+ *
+ * rewardIssuanceWorker.js / jobs/queues.js read REDIS_HOST / REDIS_PORT
+ * directly from process.env (default localhost:6379), and DATABASE_URL is
+ * set by vitest.global-setup.js — override those in the environment if your
+ * test services run elsewhere.
+ *
+ * By default the suite is skipped (with a warning) when Redis/Postgres
+ * aren't reachable, matching tests/rewardDistributionJobService.redis.test.js.
+ * Set REQUIRE_REDIS_FOR_TESTS=1 to fail hard instead of skipping (CI).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import net from 'net';
+import crypto from 'crypto';
+
+// ── Mock only the Stellar-talking processor; everything else (BullMQ,
+// Postgres, the DLQ wiring) is real. ────────────────────────────────────
+//
+// rewardIssuanceWorker.js pulls this in via a plain CJS require(), reached
+// through a dynamic import() rather than this file's own static import
+// graph — vi.mock's hoisted interception doesn't reach a require() that
+// deep, so instead we pre-seed Node's own require cache with a fake module
+// before rewardIssuanceWorker.js ever requires the real one.
+const mockProcessRewardIssuance = vi.fn();
+
+function stubRequireCache(relativeSpecifier, fakeExports) {
+  const resolvedPath = require.resolve(relativeSpecifier);
+  require.cache[resolvedPath] = {
+    id: resolvedPath,
+    filename: resolvedPath,
+    loaded: true,
+    exports: fakeExports,
+  };
+  return resolvedPath;
+}
+
+function canReach(host, port, timeoutMs = 500) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.on('connect', () => finish(true));
+    socket.on('timeout', () => finish(false));
+    socket.on('error', () => finish(false));
+  });
+}
+
+async function pollUntil(conditionFn, { timeoutMs = 10000, intervalMs = 100 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await conditionFn();
+    if (result) return result;
+    if (Date.now() >= deadline) {
+      throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+const REDIS_HOST = process.env.REDIS_HOST || 'localhost';
+const REDIS_PORT = parseInt(process.env.REDIS_PORT, 10) || 6379;
+const requireInfra = process.env.REQUIRE_REDIS_FOR_TESTS === '1';
+
+// Custom error type so the Prometheus `reason` label (which reads err.name)
+// is something more meaningful than the generic "Error".
+class StellarTimeoutError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'StellarTimeoutError';
+  }
+}
+
+let infraAvailable = false;
+let dbPool;
+let queuesModule;
+let workerModule;
+
+async function insertedFailureFor(jobId) {
+  const result = await dbPool.query('SELECT * FROM reward_issuance_failures WHERE job_id = $1', [jobId]);
+  return result.rows[0] || null;
+}
+
+async function dlqCounterValue(reason) {
+  const metric = await queuesModule.novaRewardDlqTotal.get();
+  return metric.values.find((v) => v.labels?.reason === reason)?.value || 0;
+}
+
+beforeAll(async () => {
+  const pgUrl = new URL(process.env.DATABASE_URL);
+  const [redisUp, pgUp] = await Promise.all([
+    canReach(REDIS_HOST, REDIS_PORT),
+    canReach(pgUrl.hostname, parseInt(pgUrl.port || '5432', 10)),
+  ]);
+  infraAvailable = redisUp && pgUp;
+
+  if (!infraAvailable) {
+    const missing = [!redisUp && `Redis at ${REDIS_HOST}:${REDIS_PORT}`, !pgUp && `Postgres at ${pgUrl.host}`]
+      .filter(Boolean)
+      .join(', ');
+    if (requireInfra) {
+      throw new Error(`Required test infra unreachable: ${missing}. Run docker-compose -f docker-compose.test.yml up -d`);
+    }
+    console.warn(`Skipping rewardIssuanceWorker DLQ integration tests: ${missing} unreachable`);
+    return;
+  }
+
+  // Import lazily (rather than statically) so a Redis/Postgres-less run
+  // never constructs a real BullMQ Queue/Worker and never risks an
+  // unhandled 'error' event from a doomed connection attempt.
+  stubRequireCache('../services/rewardIssuanceService', {
+    processRewardIssuance: (...args) => mockProcessRewardIssuance(...args),
+  });
+
+  queuesModule = await import('../jobs/queues.js');
+  workerModule = await import('../jobs/rewardIssuanceWorker.js');
+
+  const { Pool } = await import('pg');
+  dbPool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  await queuesModule.rewardIssuanceQueue.waitUntilReady();
+  await workerModule.worker.waitUntilReady();
+});
+
+afterAll(async () => {
+  if (!infraAvailable) return;
+
+  await workerModule.shutdownWorker();
+  await queuesModule.shutdownQueues();
+  await dbPool.end();
+});
+
+describe('rewardIssuanceWorker DLQ persistence (integration)', () => {
+  it('routes a job that fails all 3 attempts to the DLQ and persists it to reward_issuance_failures', async () => {
+    if (!infraAvailable) return;
+
+    const errorMessage = 'Simulated permanent Stellar failure';
+    mockProcessRewardIssuance.mockRejectedValue(new StellarTimeoutError(errorMessage));
+
+    const counterBefore = await dlqCounterValue('StellarTimeoutError');
+
+    const testMarker = crypto.randomUUID();
+    const job = await queuesModule.rewardIssuanceQueue.add(
+      'issue-reward',
+      { campaignId: 1, walletAddress: 'GTEST_ALWAYS_FAILS', amount: '10', testMarker },
+      { attempts: 3, backoff: { type: 'fixed', delay: 50 } }
+    );
+
+    // 1. Job appears in the reward-issuance-dlq queue.
+    const dlqEntry = await pollUntil(async () => {
+      const jobs = await workerModule.rewardDLQ.getJobs(['waiting', 'active']);
+      return jobs.find((j) => j.data?.testMarker === testMarker) || null;
+    });
+    expect(dlqEntry.data).toEqual(
+      expect.objectContaining({
+        campaignId: 1,
+        walletAddress: 'GTEST_ALWAYS_FAILS',
+        amount: '10',
+        failedReason: errorMessage,
+      })
+    );
+
+    // 2. Failure is persisted to reward_issuance_failures with the error message.
+    const dbRow = await pollUntil(() => insertedFailureFor(job.id));
+    expect(dbRow.attempts).toBe(3);
+    expect(dbRow.error).toBe(errorMessage);
+    expect(dbRow.payload).toEqual(
+      expect.objectContaining({ campaignId: 1, walletAddress: 'GTEST_ALWAYS_FAILS', testMarker })
+    );
+
+    // 3. nova_reward_dlq_total incremented by 1 for this failure reason.
+    const counterAfter = await dlqCounterValue('StellarTimeoutError');
+    expect(counterAfter - counterBefore).toBe(1);
+
+    expect(mockProcessRewardIssuance).toHaveBeenCalledTimes(3);
+  }, 15000);
+
+  it('does not route a job that succeeds on attempt 1 to the DLQ or the DB', async () => {
+    if (!infraAvailable) return;
+
+    mockProcessRewardIssuance.mockReset();
+    mockProcessRewardIssuance.mockResolvedValue({ status: 'issued', txHash: 'tx-success' });
+
+    const testMarker = crypto.randomUUID();
+    const job = await queuesModule.rewardIssuanceQueue.add(
+      'issue-reward',
+      { campaignId: 2, walletAddress: 'GTEST_SUCCEEDS', amount: '5', testMarker },
+      { attempts: 3, backoff: { type: 'fixed', delay: 50 } }
+    );
+
+    // Queue default is removeOnComplete: true, so a successful job disappears
+    // from Redis once the Worker finishes with it — that's our completion signal.
+    await pollUntil(async () => {
+      const stillQueued = await queuesModule.rewardIssuanceQueue.getJob(job.id);
+      return stillQueued === undefined;
+    });
+
+    expect(mockProcessRewardIssuance).toHaveBeenCalledTimes(1);
+
+    const dlqJobs = await workerModule.rewardDLQ.getJobs(['waiting', 'active']);
+    expect(dlqJobs.find((j) => j.data?.testMarker === testMarker)).toBeUndefined();
+
+    const dbRow = await insertedFailureFor(job.id);
+    expect(dbRow).toBeNull();
+  }, 15000);
+});

--- a/novaRewards/backend/tests/shutdown.test.js
+++ b/novaRewards/backend/tests/shutdown.test.js
@@ -52,7 +52,7 @@ vi.mock('../services/rewardIssuanceService', () => ({
   processRewardIssuance: vi.fn().mockResolvedValue({ status: 'ok' }),
 }));
 
-vi.mock('../repositories/rewardIssuanceRepository', () => ({
+vi.mock('../db/rewardIssuanceRepository', () => ({
   default: {
     getByRewardId: vi.fn().mockResolvedValue(null),
   },


### PR DESCRIPTION
Closes #1233.

## Summary

Adds `novaRewards/backend/tests/rewardIssuanceWorkerDlq.test.js`: a real-Redis/real-Postgres integration test covering the reward-issuance DLQ path, per the issue's acceptance criteria:
- A job that fails all 3 attempts appears in the `reward-issuance-dlq` queue.
- The failure is persisted to `reward_issuance_failures` with the correct error message and attempt count.
- A job that succeeds on attempt 1 does **not** appear in the DLQ or the DB.
- The `nova_reward_dlq_total` Prometheus counter increments by 1 per DLQ entry.

It skips gracefully (with a warning) when the `docker-compose.test.yml` Redis/Postgres services aren't reachable, matching the existing `rewardDistributionJobService.redis.test.js` pattern; set `REQUIRE_REDIS_FOR_TESTS=1` to fail hard instead (recommended for CI).

## Bugs found & fixed along the way

Writing a *real* integration test (rather than a fully-mocked one) surfaced three pre-existing bugs that made the reward-issuance worker path unloadable or silently inert. Fixing them was necessary to have anything real to test against, so they're included here rather than filed separately:

1. **`jobs/rewardIssuanceWorker.js` required a module that doesn't exist.** It required `'../repositories/rewardIssuanceRepository'`, but that file lives at `'../db/rewardIssuanceRepository'`. This means `require("./jobs/rewardIssuanceWorker")` in `server.js` would throw `MODULE_NOT_FOUND` on every server startup that reaches it — reproduced with a bare `node -e "require('./jobs/rewardIssuanceWorker.js')"`, no test framework involved.
2. **`services/rewardIssuanceService.js` used extension-less relative ESM imports** (e.g. `from '../jobs/queues'`). Node's ESM resolver — unlike CJS — doesn't auto-resolve extensions, so requiring this file outside of a fully static import graph (e.g. from `rewardIssuanceWorker.js`'s `require()`) threw `ERR_MODULE_NOT_FOUND`. Added the missing `.js` extensions to its four relative imports.
3. **The DLQ DB-persistence handler in `jobs/queues.js` was dead code against real Redis.** It was registered as `rewardIssuanceQueue.on('failed', ...)` on a plain BullMQ `Queue` instance — but a bare `Queue` never locally emits job-lifecycle events like `'failed'`/`'completed'` (only `Worker` and `QueueEvents` do). That means failures were never actually written to `reward_issuance_failures` and the Prometheus counter never moved, despite the code looking correct and being unit-tested against a fully-mocked BullMQ. Extracted the logic to an exported `handleRewardIssuanceFailure(job, err)` and call it from `rewardIssuanceWorker.js`'s `worker.on('failed', ...)` handler, which does fire for real (the registration on the queue is left in place for the existing mocked unit-test coverage).

Also updated `tests/shutdown.test.js`'s mock path (`'../repositories/rewardIssuanceRepository'` → `'../db/rewardIssuanceRepository'`) to match the corrected `require()` target — it was mocking a path that was never actually being required.

**Not fixed here (out of scope, flagged for follow-up):** `rewardIssuanceWorker.js`'s idempotency guard calls `rewardIssuanceRepository.getByRewardId(rewardId)`, but that method is never defined/exported by `db/rewardIssuanceRepository.js` — it only exports `createIssuance, getIssuanceByKey, markConfirmed, markFailed, incrementAttempts`. This doesn't block the new test (test job payloads don't set `rewardId`, so the guard's `if (rewardId)` branch is never entered), but the idempotency check is presently non-functional whenever a job does carry a `rewardId`. Also, `docker-compose.test.yml` currently contains literal `\n` escape sequences instead of real newlines, and the `reward_issuance_failures` table's migration (`migrations/20260717000001_create_reward_issuance_failures.js`, knex format) has no wired-up runner in this repo (no knexfile/knex dependency) — worth a follow-up to get it into the SQL migration flow `database/migrate.js` actually runs.

## Test plan

- New integration test run against `docker-compose.test.yml`-equivalent services (real BullMQ + Redis + Postgres), 3x in a row for flakiness — consistently passing.
- Verified the graceful-skip path by stopping Redis/Postgres and re-running — skips cleanly with a warning, no false failure.
- Verified all three fixed bugs by reproducing each with a bare `node -e "require('./jobs/rewardIssuanceWorker.js')"` (no test framework) before and after the fix.
- Compared full `vitest run` and the directly-affected test files against unmodified `main` via `git stash`: no regressions, net improvement (821 vs 815 passing on the full suite; `shutdown.test.js` alone went from 1/14 to 4/14 passing — its remaining failures are pre-existing and unrelated, caused by `vi.mock('bullmq')` not reliably intercepting a dynamically-imported CJS module's nested `require()` calls, which now also pre-exists on `main` once the module can actually load).

