### PR TITLE
fix(auth): keep JWT access token in memory only, not localStorage

### DIFF
--- a/novaRewards/frontend/__tests__/authStore.test.js
+++ b/novaRewards/frontend/__tests__/authStore.test.js
@@ -1,0 +1,99 @@
+import { useAuthStore } from '../store/authStore';
+
+/**
+ * Tests for authStore's persistence behavior.
+ *
+ * Focus: confirm the `token` field is held in memory only and never
+ * written to localStorage, while `user`/`isAuthenticated` continue to be
+ * persisted and restored across reloads (the security-boundary contract
+ * documented in authStore.js).
+ */
+
+const STORAGE_KEY = 'nova-auth-storage';
+
+const mockUser = { id: 'user-1', firstName: 'Ada', stellarPublicKey: 'G...ABC' };
+const mockToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mock-payload.mock-signature';
+
+function resetStore() {
+  useAuthStore.setState({ user: null, token: null, isAuthenticated: false });
+  localStorage.clear();
+}
+
+describe('authStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('starts with no user, no token, and isAuthenticated false', () => {
+    const state = useAuthStore.getState();
+    expect(state.user).toBeNull();
+    expect(state.token).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+  });
+
+  it('login sets user, token, and isAuthenticated in memory', () => {
+    useAuthStore.getState().login(mockUser, mockToken);
+
+    const state = useAuthStore.getState();
+    expect(state.user).toEqual(mockUser);
+    expect(state.token).toBe(mockToken);
+    expect(state.isAuthenticated).toBe(true);
+  });
+
+  it('does not persist token to localStorage after login', () => {
+    useAuthStore.getState().login(mockUser, mockToken);
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const persisted = JSON.parse(raw);
+    expect(persisted.state.token).toBeUndefined();
+    expect(raw).not.toContain(mockToken);
+  });
+
+  it('persists user and isAuthenticated to localStorage after login', () => {
+    useAuthStore.getState().login(mockUser, mockToken);
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(persisted.state.user).toEqual(mockUser);
+    expect(persisted.state.isAuthenticated).toBe(true);
+  });
+
+  it('updateUser merges new fields without reintroducing token into storage', () => {
+    useAuthStore.getState().login(mockUser, mockToken);
+    useAuthStore.getState().updateUser({ firstName: 'Ngozi' });
+
+    const state = useAuthStore.getState();
+    expect(state.user.firstName).toBe('Ngozi');
+    expect(state.user.id).toBe(mockUser.id);
+    expect(state.token).toBe(mockToken); // still in memory
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(persisted.state.token).toBeUndefined();
+  });
+
+  it('logout clears in-memory state and leaves no token in persisted storage', () => {
+    useAuthStore.getState().login(mockUser, mockToken);
+    useAuthStore.getState().logout();
+
+    const state = useAuthStore.getState();
+    expect(state.user).toBeNull();
+    expect(state.token).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+
+    // Zustand's persist middleware re-writes the storage key on every
+    // set() call (including the one inside logout()), so the key itself
+    // isn't removed — but it must never contain a token, before or after.
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw);
+    expect(persisted.state.token).toBeUndefined();
+    expect(persisted.state.user).toBeNull();
+    expect(persisted.state.isAuthenticated).toBe(false);
+    expect(raw).not.toContain(mockToken);
+  });
+});

--- a/novaRewards/frontend/store/authStore.js
+++ b/novaRewards/frontend/store/authStore.js
@@ -4,6 +4,16 @@ import { persist, devtools } from 'zustand/middleware';
 /**
  * authStore handles authentication state (user, token, login/logout).
  * Requirements: Auth persistence, DevTools support.
+ *
+ * Security boundary: `token` is intentionally excluded from the persisted
+ * (localStorage) slice via `partialize` below. JWTs held in localStorage
+ * are readable by any script on the page, which makes them a straightforward
+ * target for XSS-based theft. `token` therefore lives in memory only and is
+ * reset on every full page load/reload. Only non-sensitive fields
+ * (`user`, `isAuthenticated`) are persisted so the UI can restore a "logged
+ * in" shell on reload; callers needing a token after reload must obtain a
+ * fresh one via the refresh-token flow (refresh tokens are HTTP-only
+ * cookies, never touched by this store).
  */
 export const useAuthStore = create(
   devtools(
@@ -16,7 +26,8 @@ export const useAuthStore = create(
         /**
          * Sets user and token after successful login.
          * @param {object} user - User object from API.
-         * @param {string} token - JWT token.
+         * @param {string} token - JWT token. Kept in memory only — see
+         *   security boundary note above; never written to localStorage.
          */
         login: (user, token) => 
           set({ user, token, isAuthenticated: true }, false, 'auth/login'),
@@ -41,9 +52,10 @@ export const useAuthStore = create(
       }),
       {
         name: 'nova-auth-storage', // Name of the item in storage (localStorage by default)
+        // `token` is deliberately omitted — see security boundary JSDoc above.
+        // Only non-sensitive fields are persisted across reloads.
         partialize: (state) => ({ 
           user: state.user, 
-          token: state.token, 
           isAuthenticated: state.isAuthenticated 
         }),
       }


### PR DESCRIPTION
## Description

Removes `token` from `authStore.js`'s Zustand `persist` `partialize`, so the
JWT access token is held in memory only and never written to
`localStorage`. Only `user` and `isAuthenticated` continue to persist
across reloads.

## Why

JWTs in `localStorage` are readable by any script on the page, making them
a straightforward target for XSS-based theft. Keeping the token in memory
only closes that specific exposure for this store.

## Changes

- `novaRewards/frontend/store/authStore.js` — removed `token` from
  `partialize`; added JSDoc documenting the security boundary (token in
  memory, user metadata persisted)
- `novaRewards/frontend/__tests__/authStore.test.js` — new tests covering
  initial state, `login`, `logout`, and `updateUser`, all asserting `token`
  never appears in the persisted `localStorage` blob

## Testing

Ran locally:
<!-- Anything a reviewer should know: trade-offs made, follow-up issues, known limitations. -->

Close #1243
