### PR TITLE
fix(contract_state): refresh TTL for state metadata

### DIFF
--- a/contracts/contract_state/src/lib.rs
+++ b/contracts/contract_state/src/lib.rs
@@ -28,24 +28,26 @@ pub const EVENT_SCHEMA_VERSION: u32 = 1;
 // ── Types ─────────────────────────────────────────────────────────────────────
 #[contracttype]
 pub enum DataKey {
+    /// Instance storage. Critical admin metadata; contract instance TTL refreshed to `TTL`.
     Admin,
-    /// Schema version counter
+    /// Instance storage. Schema version counter; contract instance TTL refreshed to `TTL`.
     Version,
-    /// Live state entry
+    /// Persistent storage. Live state entry; entry TTL refreshed to `TTL` on read/write paths.
     State(Bytes),
-    /// Snapshot: (key, version) -> value
+    /// Persistent storage. Snapshot value; entry TTL refreshed to `TTL` on snapshot/recovery paths.
     Snapshot(Bytes, u32),
-    /// Multisig signers for upgrade authorization
+    /// Instance storage. Multisig signer set; contract instance TTL refreshed to `TTL`.
     Signers,
-    /// Minimum approvals required for upgrade
+    /// Instance storage. Upgrade approval threshold; contract instance TTL refreshed to `TTL`.
     Threshold,
-    /// Pending upgrade approvals: wasm_hash -> Vec<Address>
+    /// Instance storage. Pending upgrade approvals; contract instance TTL refreshed to `TTL`.
     UpgradeApprovals(BytesN<32>),
 }
 
 // ── Event helpers ─────────────────────────────────────────────────────────────
 
 fn emit_state_set(env: &Env, schema_version: u32) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("state"), symbol_short!("set")),
         (EVENT_SCHEMA_VERSION, schema_version),
@@ -53,6 +55,7 @@ fn emit_state_set(env: &Env, schema_version: u32) {
 }
 
 fn emit_state_delete(env: &Env, schema_version: u32) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("state"), symbol_short!("delete")),
         (EVENT_SCHEMA_VERSION, schema_version),
@@ -60,6 +63,7 @@ fn emit_state_delete(env: &Env, schema_version: u32) {
 }
 
 fn emit_snapshot(env: &Env, schema_version: u32) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("state"), symbol_short!("snapshot")),
         (EVENT_SCHEMA_VERSION, schema_version),
@@ -67,6 +71,7 @@ fn emit_snapshot(env: &Env, schema_version: u32) {
 }
 
 fn emit_migrate(env: &Env, new_version: u32) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("state"), symbol_short!("migrate")),
         (EVENT_SCHEMA_VERSION, new_version),
@@ -74,6 +79,7 @@ fn emit_migrate(env: &Env, new_version: u32) {
 }
 
 fn emit_recover(env: &Env, snap_version: u32) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("state"), symbol_short!("recover")),
         (EVENT_SCHEMA_VERSION, snap_version),
@@ -81,6 +87,7 @@ fn emit_recover(env: &Env, snap_version: u32) {
 }
 
 fn emit_contract_upgraded(env: &Env, new_wasm_hash: &BytesN<32>) {
+    #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("state"), symbol_short!("upgraded")),
         (EVENT_SCHEMA_VERSION, new_wasm_hash.clone()),
@@ -93,6 +100,10 @@ pub struct StateContract;
 
 #[contractimpl]
 impl StateContract {
+    fn bump_instance_ttl(env: &Env) {
+        env.storage().instance().extend_ttl(TTL, TTL);
+    }
+
     /// Initialize the contract.
     ///
     /// # Parameters
@@ -111,14 +122,19 @@ impl StateContract {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Version, &0_u32);
         env.storage().instance().set(&DataKey::Signers, &signers);
-        env.storage().instance().set(&DataKey::Threshold, &threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &threshold);
+        Self::bump_instance_ttl(&env);
     }
 
     fn admin(env: &Env) -> Address {
+        Self::bump_instance_ttl(env);
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
     fn version(env: &Env) -> u32 {
+        Self::bump_instance_ttl(env);
         env.storage().instance().get(&DataKey::Version).unwrap_or(0)
     }
 
@@ -226,6 +242,7 @@ impl StateContract {
     /// - `"already approved"` if `signer` has already approved this hash.
     pub fn approve_upgrade(env: Env, signer: Address, new_wasm_hash: BytesN<32>) {
         signer.require_auth();
+        Self::bump_instance_ttl(&env);
 
         let signers: Vec<Address> = env
             .storage()
@@ -262,6 +279,7 @@ impl StateContract {
     }
 
     pub fn get_upgrade_approvals(env: Env, new_wasm_hash: BytesN<32>) -> u32 {
+        Self::bump_instance_ttl(&env);
         let approval_key = DataKey::UpgradeApprovals(new_wasm_hash);
         let approvals: Vec<Address> = env
             .storage()
@@ -272,6 +290,7 @@ impl StateContract {
     }
 
     pub fn get_threshold(env: Env) -> u32 {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&DataKey::Threshold)
@@ -279,6 +298,7 @@ impl StateContract {
     }
 
     pub fn get_signers(env: Env) -> Vec<Address> {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&DataKey::Signers)

--- a/contracts/contract_state/src/lib.rs
+++ b/contracts/contract_state/src/lib.rs
@@ -218,6 +218,7 @@ impl StateContract {
             .persistent()
             .get(&snap_key)
             .expect("snapshot not found");
+        env.storage().persistent().extend_ttl(&snap_key, TTL, TTL);
         let state_key = DataKey::State(key);
         env.storage().persistent().set(&state_key, &value);
         env.storage().persistent().extend_ttl(&state_key, TTL, TTL);

--- a/contracts/contract_state/tests/ttl_tests.rs
+++ b/contracts/contract_state/tests/ttl_tests.rs
@@ -1,0 +1,65 @@
+#![cfg(test)]
+
+use contract_state::{StateContract, StateContractClient};
+use soroban_sdk::{
+    testutils::{
+        storage::{Instance as _, Persistent as _},
+        Address as _, Ledger as _,
+    },
+    vec, Address, Bytes, Env,
+};
+
+fn setup() -> (Env, Address, Address, StateContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(StateContract, ());
+    let client = StateContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &vec![&env, admin.clone()], &1);
+    (env, id, admin, client)
+}
+
+#[test]
+fn get_refreshes_persistent_state_ttl() {
+    let (env, contract_id, _admin, client) = setup();
+    let key = Bytes::from_slice(&env, b"ttl-state");
+    let value = Bytes::from_slice(&env, b"alive");
+    client.set(&key, &value);
+
+    env.ledger()
+        .with_mut(|ledger| ledger.sequence_number += 100);
+    let ttl_before = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&contract_state::DataKey::State(key.clone()))
+    });
+
+    assert_eq!(client.get(&key), value);
+
+    let ttl_after = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&contract_state::DataKey::State(key.clone()))
+    });
+    assert!(
+        ttl_after > ttl_before,
+        "expected get() to refresh persistent entry TTL"
+    );
+}
+
+#[test]
+fn get_version_refreshes_contract_instance_ttl() {
+    let (env, contract_id, _admin, client) = setup();
+
+    env.ledger()
+        .with_mut(|ledger| ledger.sequence_number += 100);
+    let ttl_before = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+
+    assert_eq!(client.get_version(), 0);
+
+    let ttl_after = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+    assert!(
+        ttl_after > ttl_before,
+        "expected get_version() to refresh contract instance TTL"
+    );
+}

--- a/contracts/contract_state/tests/ttl_tests.rs
+++ b/contracts/contract_state/tests/ttl_tests.rs
@@ -63,3 +63,35 @@ fn get_version_refreshes_contract_instance_ttl() {
         "expected get_version() to refresh contract instance TTL"
     );
 }
+
+#[test]
+fn recover_refreshes_snapshot_ttl() {
+    let (env, contract_id, _admin, client) = setup();
+    let key = Bytes::from_slice(&env, b"ttl-snapshot");
+    let first = Bytes::from_slice(&env, b"first");
+    let second = Bytes::from_slice(&env, b"second");
+
+    client.set(&key, &first);
+    client.snapshot(&key);
+    client.set(&key, &second);
+
+    env.ledger()
+        .with_mut(|ledger| ledger.sequence_number += 100);
+    let ttl_before = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&contract_state::DataKey::Snapshot(key.clone(), 0))
+    });
+
+    client.recover(&key, &0);
+
+    let ttl_after = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&contract_state::DataKey::Snapshot(key.clone(), 0))
+    });
+    assert!(
+        ttl_after > ttl_before,
+        "expected recover() to refresh snapshot TTL"
+    );
+}

--- a/docs/contract-storage.md
+++ b/docs/contract-storage.md
@@ -105,6 +105,22 @@ fn balance_of(env: &Env, addr: &Address) -> i128 {
 - Configuration stored in instance (no TTL)
 - Withdrawal history extended on `withdraw()` calls
 
+### Contract State Contract
+- [x] Admin address → Instance storage (refresh contract instance TTL on access)
+- [x] Schema version → Instance storage (refresh contract instance TTL on access)
+- [x] Signers → Instance storage (refresh contract instance TTL on access)
+- [x] Threshold → Instance storage (refresh contract instance TTL on access)
+- [x] Upgrade approvals → Instance storage (refresh contract instance TTL on access)
+- [x] Live state entries → Persistent storage (extend on read/write)
+- [x] Snapshot entries → Persistent storage (extend on snapshot/recovery)
+- [x] Temporary entries → Not used by this contract
+
+**Cost Optimization:**
+- Critical instance-backed metadata is refreshed via `env.storage().instance().extend_ttl(...)`
+  during initialization and subsequent read/write paths.
+- Live state and snapshot entries refresh their persistent TTL when they are written,
+  read, snapshotted, or recovered.
+
 ## Benchmarking
 
 ### Before Optimization

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -27,6 +27,7 @@ All Nova Rewards smart contracts are deployed on the Stellar network using the S
 | `referral` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
 | `distribution` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
 | `admin_roles` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `contract_state` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
 
 ### Mainnet
 
@@ -40,6 +41,7 @@ All Nova Rewards smart contracts are deployed on the Stellar network using the S
 | `referral` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
 | `distribution` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
 | `admin_roles` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `contract_state` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
 
 ---
 
@@ -110,12 +112,19 @@ stellar contract invoke \
   --token_id <NOVA_TOKEN_CONTRACT_ID>
 ```
 
+For `contract_state`, the initialization path seeds the critical instance-backed
+keys (`Admin`, `Version`, `Signers`, `Threshold`) and immediately extends the
+contract instance TTL. Subsequent version, admin, and upgrade-approval paths
+refresh the instance TTL, while state and snapshot entries refresh their
+persistent TTL on read/write paths.
+
 ---
 
 ## Contract Dependencies
 
 ```
 admin_roles          (standalone)
+contract_state       (standalone)
 nova_token           (standalone)
 reward_pool          (standalone)
 vesting              (standalone)


### PR DESCRIPTION
## Summary
- audit `contract_state` storage durability and annotate each `DataKey` with its storage class
- refresh contract instance TTL on initialization and instance-backed access paths
- add TTL regression tests for persistent reads, instance reads, and snapshot recovery
- document that `contract_state` uses instance and persistent storage only, with no temporary entries today

## Test Plan
- [x] `cargo test -p contract_state`
- [x] `cargo clippy -p contract_state --tests -- -D warnings`
- [x] red/green/sabotage cycle for `get_version_refreshes_contract_instance_ttl`
- [x] red/green/sabotage cycle for `recover_refreshes_snapshot_ttl`

Closes #1130