### PR TITLE
fix: merge duplicate headers() in next.config.js restoring CSP and cache rules (closes #1302)

### DIFF
--- a/novaRewards/frontend/__tests__/next-config-headers.test.js
+++ b/novaRewards/frontend/__tests__/next-config-headers.test.js
@@ -1,0 +1,37 @@
+/**
+ * Regression test for Nova-Rewards#1302: duplicate `headers()` keys in
+ * next.config.js silently dropped the CSP header and static-asset caching.
+ * Asserts the single merged headers() serves the full security set plus
+ * the cache rules.
+ */
+const nextConfig = require('../next.config.js');
+
+describe('next.config.js headers()', () => {
+  let routes;
+
+  beforeAll(async () => {
+    expect(typeof nextConfig.headers).toBe('function');
+    routes = await nextConfig.headers();
+  });
+
+  const headersFor = (source) => {
+    const route = routes.find((r) => r.source === source);
+    expect(route).toBeDefined();
+    return Object.fromEntries(route.headers.map((h) => [h.key, h.value]));
+  };
+
+  it('serves the full security header set on /(.*)', () => {
+    const h = headersFor('/(.*)');
+    expect(h['Content-Security-Policy']).toMatch(/default-src 'self'/);
+    expect(h['X-Frame-Options']).toBe('DENY');
+    expect(h['X-Content-Type-Options']).toBe('nosniff');
+    expect(h['Strict-Transport-Security']).toMatch(/max-age=31536000/);
+    expect(h['Referrer-Policy']).toBeDefined();
+    expect(h['Permissions-Policy']).toBeDefined();
+  });
+
+  it('serves long-lived cache rules for static assets', () => {
+    const h = headersFor('/_next/static/(.*)');
+    expect(h['Cache-Control']).toMatch(/max-age=31536000/);
+  });
+});

--- a/novaRewards/frontend/__tests__/next-config-headers.test.js
+++ b/novaRewards/frontend/__tests__/next-config-headers.test.js
@@ -4,6 +4,7 @@
  * Asserts the single merged headers() serves the full security set plus
  * the cache rules.
  */
+const { readFileSync } = require('fs');
 const nextConfig = require('../next.config.js');
 
 describe('next.config.js headers()', () => {
@@ -28,6 +29,18 @@ describe('next.config.js headers()', () => {
     expect(h['Strict-Transport-Security']).toMatch(/max-age=31536000/);
     expect(h['Referrer-Policy']).toBeDefined();
     expect(h['Permissions-Policy']).toBeDefined();
+    // Kept deliberately per #1302. `mode=block` matters: a bare `1` is the
+    // variant with a known cross-site leak, so assert the value, not presence.
+    expect(h['X-XSS-Protection']).toBe('1; mode=block');
+  });
+
+  it('exposes exactly one headers() definition', () => {
+    // The original bug was two `async headers()` keys in one object literal,
+    // where the second silently won. Reading the source is the only way to see
+    // it from a test: the evaluated config already collapsed to the last one.
+    const source = readFileSync(require.resolve('../next.config.js'), 'utf8');
+    const definitions = source.match(/^\s*async headers\(\)/gm) || [];
+    expect(definitions).toHaveLength(1);
   });
 
   it('serves long-lived cache rules for static assets', () => {

--- a/novaRewards/frontend/eslint.config.js
+++ b/novaRewards/frontend/eslint.config.js
@@ -11,4 +11,17 @@ module.exports = [
     ignores: ['node_modules/', '.next/', 'coverage/', 'dist/', 'build/', '.storybook/', 'storybook-static/', 'eslint.config.js', '.eslintrc.js', '.eslintrc.json'],
   },
   ...compat.extends('next/core-web-vitals'),
+  {
+    // #1302: two `async headers()` keys in one object literal silently overwrote
+    // each other, dropping the CSP and every static-asset Cache-Control rule from
+    // production responses. Nothing surfaced it — `next build` is silent and the
+    // shipped config extends only next/core-web-vitals, which does not turn this on.
+    //
+    // The issue assumed `no-dupe-keys` does not cover object *methods*. It does:
+    // ESLint reports "Duplicate key 'headers'" for the exact shorthand-method
+    // pattern that caused this bug, so enabling the rule is the whole fix.
+    rules: {
+      'no-dupe-keys': 'error',
+    },
+  },
 ];

--- a/novaRewards/frontend/next.config.js
+++ b/novaRewards/frontend/next.config.js
@@ -17,6 +17,12 @@ const securityHeaders = [
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload' },
+  // Kept deliberately (#1302 asked for an explicit call rather than an accidental one).
+  // Chrome, Edge and Safari removed the XSS Auditor and ignore this header; the real
+  // protection is the Content-Security-Policy above. It is retained only because
+  // `1; mode=block` is still honoured by older browsers and costs one response header
+  // with no downside — the known footgun is `1` alone (no `mode=block`), which can
+  // introduce a cross-site leak. Drop this line once those browsers are out of scope.
   { key: 'X-XSS-Protection', value: '1; mode=block' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },

--- a/novaRewards/frontend/next.config.js
+++ b/novaRewards/frontend/next.config.js
@@ -15,6 +15,7 @@ if (process.env.JEST_WORKER_ID === undefined && process.env.NODE_ENV !== 'test')
 const securityHeaders = [
   { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" },
   { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload' },
   { key: 'X-XSS-Protection', value: '1; mode=block' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
@@ -79,35 +80,6 @@ const nextConfig = {
   },
   sentry: {
     // Deprecated in v10 — options moved to sentryWebpackPluginOptions below
-  },
-  async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: [
-          {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=31536000; includeSubDomains; preload',
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'DENY',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=()',
-          },
-        ],
-      },
-    ];
   },
 };
 


### PR DESCRIPTION
Closes #1302.

### Root cause

Two `async headers()` keys in one object literal; the second silently overwrote the first, dropping CSP, X-XSS-Protection, and all static-asset `Cache-Control` rules from every response.

### Changes

- `novaRewards/frontend/next.config.js`: single merged `headers()` = union of both sets (adds `X-Content-Type-Options: nosniff` to the security set, keeps all cache rules). Net -27 lines.
- `novaRewards/frontend/eslint.config.js`: enable `no-dupe-keys`, so this class of bug fails lint instead of shipping silently.
- `novaRewards/frontend/__tests__/next-config-headers.test.js` (new): asserts the full security set on `/(.*)`, long-lived cache on `/_next/static`, and exactly one `headers()` definition in the source.

### On `no-dupe-keys` — the issue's assumption was wrong

#1302 suggested `no-dupe-keys` "doesn't cover object *methods*". It does. ESLint reports `Duplicate key 'headers'` for exactly the shorthand-method pattern that caused this bug, so enabling the rule *is* the prevention — no custom check needed.

Verified both directions against this repo's own `next.config.js`:

```
# merged config (this PR)
$ eslint --rule '{"no-dupe-keys":"error"}' next.config.js
   -> clean, exit 0

# second `async headers()` deliberately reintroduced
$ eslint --rule '{"no-dupe-keys":"error"}' next.config.js
   51:9  error  Duplicate key 'headers'  no-dupe-keys
```

The reason nothing caught this originally: the shipped `eslint.config.js` extends only `next/core-web-vitals`, which does not enable the rule.

### On `X-XSS-Protection` — explicit call, as asked

#1302 asked for this to be "a call to make explicitly rather than by accident". **Kept**, and the reasoning is now recorded in the config: Chrome, Edge and Safari removed the XSS Auditor and ignore the header, so the real protection is the CSP above. It is retained only because `1; mode=block` is still honoured by older browsers and costs one response header with no downside — the known footgun is a bare `1` without `mode=block`, which can introduce a cross-site leak. The test asserts the exact value rather than presence, so the unsafe variant cannot creep in.

### Why a source-level test for the duplicate

The evaluated config can never reveal the duplicate — by the time it is an object, the last key has already won. The only way to see it from a test is to read the file, which is what the third assertion does.

### Verification

- `eslint --rule '{"no-dupe-keys":"error"}'` on `next.config.js`: clean; fails as shown above when the bug is reintroduced.
- `node --check`: clean.
- Header assertions were run green in the first pass; CI on this branch has not reported (no workflow runs appear on the PR — they may need maintainer approval for a first-time contributor).
