### PR TITLE
fix(nova-rewards): make the crate compile under testutils by replacing Option<StakeRecord> in AccountSnapshot (closes #1298)

### DIFF
--- a/contracts/nova-rewards/src/lib.rs
+++ b/contracts/nova-rewards/src/lib.rs
@@ -45,11 +45,42 @@ pub struct StakeRecord {
     pub last_claimed_at: u64,
 }
 
+/// Optional stake held inside an [`AccountSnapshot`].
+///
+/// `#[contracttype]` structs cannot hold `Option<UserType>` fields when the
+/// SDK's `testutils` feature is on (no `ScVal: From<StakeRecord>` exists for the
+/// generated XDR conversion), which broke `cargo test` for the whole workspace.
+/// A contract enum encodes the same "maybe a stake" state and converts cleanly.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SnapshotStake {
+    None,
+    Some(StakeRecord),
+}
+
+impl SnapshotStake {
+    pub fn into_option(self) -> Option<StakeRecord> {
+        match self {
+            SnapshotStake::None => None,
+            SnapshotStake::Some(stake) => Some(stake),
+        }
+    }
+}
+
+impl From<Option<StakeRecord>> for SnapshotStake {
+    fn from(stake: Option<StakeRecord>) -> Self {
+        match stake {
+            Some(stake) => SnapshotStake::Some(stake),
+            None => SnapshotStake::None,
+        }
+    }
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AccountSnapshot {
     pub balance: i128,
-    pub stake: Option<StakeRecord>,
+    pub stake: SnapshotStake,
     pub captured_at: u64,
 }
 
@@ -1087,7 +1118,7 @@ impl NovaRewardsContract {
 
         let snapshot = AccountSnapshot {
             balance: Self::read_balance(&env, &user),
-            stake: Self::read_stake(&env, &user),
+            stake: Self::read_stake(&env, &user).into(),
             captured_at: env.ledger().timestamp(),
         };
 
@@ -1133,7 +1164,7 @@ impl NovaRewardsContract {
             .expect("snapshot not found");
 
         Self::write_balance(&env, &user, snapshot.balance);
-        if let Some(stake) = snapshot.stake.clone() {
+        if let Some(stake) = snapshot.stake.clone().into_option() {
             Self::write_stake(&env, &user, &stake);
         } else {
             Self::clear_stake(&env, &user);

--- a/contracts/nova-rewards/tests/recovery.rs
+++ b/contracts/nova-rewards/tests/recovery.rs
@@ -64,7 +64,7 @@ fn test_snapshot_and_restore_account_state() {
 
     let snapshot = client.snapshot_account(&user, &operation_id(&env, 1));
     assert_eq!(snapshot.balance, 600);
-    assert_eq!(snapshot.stake.unwrap().amount, 400);
+    assert_eq!(snapshot.stake.into_option().unwrap().amount, 400);
 
     client.pause(&Symbol::new(&env, "restore"));
     client.recover_transaction(&user, &150_i128, &operation_id(&env, 2));


### PR DESCRIPTION
## Summary

Closes #1298.

`cargo test` could not compile `nova-rewards` at all, even though `cargo build` worked. The dev-dependency turns on `soroban-sdk`'s `testutils` feature. With that feature on, `#[contracttype]` generates `TryFrom<&AccountSnapshot> for ScVal`, which converts each field. For `stake: Option<StakeRecord>`, stellar-xdr's `Option` impl needs `StakeRecord: Into<ScVal>` (i.e. `From`). The macro only emits `TryFrom<StakeRecord> for ScVal`, so the bound fails:

```
error[E0277]: the trait bound `ScVal: TryFrom<&Option<StakeRecord>>` is not satisfied
  --> nova-rewards/src/lib.rs:48:1
```

Adding a local `impl From<StakeRecord> for ScVal` doesn't work either. It collides with the macro-generated `TryFrom` through the blanket impl (E0119).

## Change

- Add a `SnapshotStake` contract enum (`None` / `Some(StakeRecord)`). It encodes the same "maybe a stake" state and converts to XDR without problems.
- `AccountSnapshot.stake` is now `SnapshotStake`. Two helpers keep call sites small: `From<Option<StakeRecord>>` and `into_option()`.
- Update the two internal uses (`snapshot_account`, `restore_account`) and the one test assertion in `tests/recovery.rs`.

Behaviour stays the same: snapshot and restore still write or clear the stake exactly as before. Note that the on-chain encoding of `AccountSnapshot.stake` changes (enum instead of option). Any snapshot already stored under the old layout would need to be re-captured. Snapshots are short-lived recovery artifacts, so I think that's acceptable, but please flag it if not.

## Verification

- `cargo build -p nova-rewards`: passes
- `cargo test -p nova-rewards --lib`: now compiles and runs (previously E0277)
- The E0277 no longer appears anywhere in `cargo test --workspace --no-run`

## Out of scope (pre-existing, separate issues)

With the lib compiling, `cargo test --workspace` now gets further and surfaces unrelated breakage that was hidden behind this error:
- `distribution` and `campaign`: `unclosed delimiter` even in plain `cargo build` (bad-merge corruption, see #1303)
- `nova-rewards/tests/*`, `referral`, `redemption`: tests written against an older SDK or contract API (`events().all().iter()`, `pause(&Symbol)`, `credit_referrer`, `register_referral(..).unwrap()`)
- `admin_roles` conflicting suites (#1299)

I kept this PR scoped to #1298 so it's easy to review. I'm happy to take one of the follow-ups next.