### PR TITLE
fix(admin_roles): restore a compilable RBAC contract and align both test suites (closes #1299)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -888,14 +888,17 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 name = "integration_tests"
 version = "0.1.0"
 dependencies = [
+ "admin_roles",
  "campaign",
  "distribution",
  "escrow",
  "governance",
  "nova-rewards",
  "nova_token",
+ "referral",
  "reward_pool",
  "soroban-sdk",
+ "vesting",
 ]
 
 [[package]]

--- a/contracts/admin_roles/src/lib.rs
+++ b/contracts/admin_roles/src/lib.rs
@@ -2,24 +2,30 @@
 //!
 //! Role-based access control (RBAC) for the Nova Rewards protocol.
 //!
-//! ## Features
-//! - Two-step admin transfer (propose → accept) to prevent accidental ownership loss
-//! - Configurable multisig threshold and signer set
-//! - Privileged stubs for mint, withdraw, rate update, and pause operations
-//! - M-of-N multisig upgrade mechanism
+//! ## Roles
+//! - `ADMIN`    – full control; can grant/revoke any role and call all privileged functions.
+//! - `MERCHANT` – can call merchant-scoped privileged functions (e.g. update_rate).
+//! - `OPERATOR` – can call operator-scoped privileged functions (e.g. pause, withdraw).
 //!
-//! ## Event Schema (v1)
-//! All events include `schema_version` as the first data element.
+//! ## Usage
+//! ```ignore
+//! client.initialize(&owner, &signers_vec, &threshold);
 //!
-//! | topics                          | data                                                    |
-//! |---------------------------------|---------------------------------------------------------|
-//! | `("adm_roles", "adm_prop")`     | `(v, current_admin, proposed)`                          |
-//! | `("adm_roles", "adm_xfer")`     | `(v, old_admin, new_admin)`                             |
-//! | `("adm_roles", "role_chg")`     | `(v, admin, operation, target)`                         |
-//! | `("adm_roles", "upgraded")`     | `(v, new_wasm_hash)`                                    |
+//! // Grant / revoke roles (owner only)
+//! client.grant_role(&address, &Role::Merchant);
+//! client.revoke_role(&address, &Role::Merchant);
+//!
+//! // Two-step owner transfer
+//! client.propose_admin(&new_owner);
+//! client.accept_admin();
+//!
+//! // M-of-N WASM upgrade (signers configured at initialize)
+//! client.approve_upgrade(&signer, &new_wasm_hash);
+//! ```
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env,
+    Vec,
 };
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -32,6 +38,8 @@ pub enum Error {
     NotInitialized     = 2,
     Unauthorized       = 3,
     NoPendingAdmin     = 4,
+    NotSigner          = 5,
+    AlreadyApproved    = 6,
 }
 
 // ── Roles ─────────────────────────────────────────────────────────────────────
@@ -53,42 +61,10 @@ pub enum DataKey {
     PendingOwner,
     Signers,
     Threshold,
-    Initialized,
-    /// Pending upgrade approvals: wasm_hash -> Vec<Address>
+    /// Stores `true` when `address` holds `role`.
+    Role(Address, Role),
+    /// Signers that approved upgrading to the given WASM hash.
     UpgradeApprovals(BytesN<32>),
-}
-
-/// Schema version for all events emitted by this contract.
-pub const EVENT_SCHEMA_VERSION: u32 = 1;
-
-// ── Event helpers ─────────────────────────────────────────────────────────────
-
-fn emit_admin_proposed(env: &Env, current_admin: &Address, proposed: &Address) {
-    env.events().publish(
-        (symbol_short!("adm_roles"), symbol_short!("adm_prop")),
-        (EVENT_SCHEMA_VERSION, current_admin.clone(), proposed.clone()),
-    );
-}
-
-fn emit_admin_transferred(env: &Env, old_admin: &Address, new_admin: &Address) {
-    env.events().publish(
-        (symbol_short!("adm_roles"), symbol_short!("adm_xfer")),
-        (EVENT_SCHEMA_VERSION, old_admin.clone(), new_admin.clone()),
-    );
-}
-
-fn emit_role_changed(env: &Env, admin: &Address, operation: Symbol, target: &Address) {
-    env.events().publish(
-        (symbol_short!("adm_roles"), symbol_short!("role_chg")),
-        (EVENT_SCHEMA_VERSION, admin.clone(), operation, target.clone()),
-    );
-}
-
-fn emit_contract_upgraded(env: &Env, new_wasm_hash: &BytesN<32>) {
-    env.events().publish(
-        (symbol_short!("adm_roles"), symbol_short!("upgraded")),
-        (EVENT_SCHEMA_VERSION, new_wasm_hash.clone()),
-    );
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -98,18 +74,17 @@ pub struct AdminRolesContract;
 
 #[contractimpl]
 impl AdminRolesContract {
-    /// Initializes the contract with the first admin and optional multisig settings.
-    ///
-    /// # Parameters
-    /// - `admin` – Initial admin address.
-    /// - `signers` – Initial multisig signer set (used for both operations and upgrades).
-    /// - `threshold` – Minimum approvals required for multisig operations and upgrades.
-    ///
-    /// # Panics
-    /// - `"already initialised"` if called more than once.
-    pub fn initialize(env: Env, admin: Address, signers: Vec<Address>, threshold: u32) {
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialised");
+    // ── Init ──────────────────────────────────────────────────────────────────
+
+    /// One-time setup. The `owner` is automatically granted the `Admin` role.
+    pub fn initialize(
+        env: Env,
+        owner: Address,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Owner) {
+            return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Owner, &owner);
         env.storage().instance().set(&DataKey::Signers, &signers);
@@ -155,12 +130,6 @@ impl AdminRolesContract {
             .persistent()
             .get(&DataKey::Role(account, role))
             .unwrap_or(false)
-    fn admin(env: &Env) -> Address {
-        env.storage().instance().get(&DataKey::Admin).unwrap()
-    }
-
-    fn require_admin(env: &Env) {
-        Self::admin(env).require_auth();
     }
 
     // ── Two-step owner transfer ───────────────────────────────────────────────
@@ -180,27 +149,6 @@ impl AdminRolesContract {
 
     /// Accept ownership transfer (pending owner only).
     pub fn accept_admin(env: Env) -> Result<(), Error> {
-    /// Stores a pending admin that can later accept ownership.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "adm_prop")` with `(schema_version, current_admin, proposed)`.
-    pub fn propose_admin(env: Env, new_admin: Address) {
-        Self::require_admin(&env);
-        env.storage()
-            .instance()
-            .set(&DataKey::PendingAdmin, &new_admin);
-
-        emit_admin_proposed(&env, &Self::admin(&env), &new_admin);
-    }
-
-    /// Completes the two-step admin transfer for the pending admin.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "adm_xfer")` with `(schema_version, old_admin, new_admin)`.
-    ///
-    /// # Panics
-    /// - `"no pending admin"` if no admin transfer is in progress.
-    pub fn accept_admin(env: Env) {
         let pending: Address = env
             .storage()
             .instance()
@@ -219,14 +167,13 @@ impl AdminRolesContract {
         env.events()
             .publish((symbol_short!("adm_xfer"), old), pending);
         Ok(())
-        emit_admin_transferred(&env, &old_admin, &pending);
     }
 
     // ── Multisig ──────────────────────────────────────────────────────────────
 
-    /// Update multisig threshold. Requires `Admin` role.
+    /// Update multisig threshold. Restricted to the contract owner.
     pub fn update_threshold(env: Env, threshold: u32) -> Result<(), Error> {
-        Self::require_role(&env, &Self::caller_from_auth(&env), &Role::Admin)?;
+        Self::require_owner(&env)?;
         env.storage().instance().set(&DataKey::Threshold, &threshold);
         Ok(())
     }
@@ -237,38 +184,6 @@ impl AdminRolesContract {
         Self::require_role(&env, &caller, &Role::Admin)?;
         env.storage().instance().set(&DataKey::Signers, &signers);
         Ok(())
-    /// Updates the multisig approval threshold.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "role_chg")` with operation `"threshold"`.
-    pub fn update_threshold(env: Env, threshold: u32) {
-        Self::require_admin(&env);
-        env.storage()
-            .instance()
-            .set(&DataKey::Threshold, &threshold);
-
-        emit_role_changed(
-            &env,
-            &Self::admin(&env),
-            symbol_short!("threshold"),
-            &Self::admin(&env),
-        );
-    }
-
-    /// Replaces the configured multisig signer set.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "role_chg")` with operation `"signers"`.
-    pub fn update_signers(env: Env, signers: Vec<Address>) {
-        Self::require_admin(&env);
-        env.storage().instance().set(&DataKey::Signers, &signers);
-
-        emit_role_changed(
-            &env,
-            &Self::admin(&env),
-            symbol_short!("signers"),
-            &Self::admin(&env),
-        );
     }
 
     // ── Privileged functions (role-gated) ─────────────────────────────────────
@@ -295,42 +210,6 @@ impl AdminRolesContract {
     pub fn pause(env: Env, caller: Address) -> Result<(), Error> {
         caller.require_auth();
         Self::require_role(&env, &caller, &Role::Operator)
-    /// Placeholder privileged mint hook guarded by admin auth.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "role_chg")` with operation `"mint"` and target `to`.
-    pub fn mint(env: Env, to: Address, _amount: i128) {
-        Self::require_admin(&env);
-        emit_role_changed(&env, &Self::admin(&env), symbol_short!("mint"), &to);
-    }
-
-    /// Placeholder privileged withdrawal hook guarded by admin auth.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "role_chg")` with operation `"withdraw"` and target `to`.
-    pub fn withdraw(env: Env, to: Address, _amount: i128) {
-        Self::require_admin(&env);
-        emit_role_changed(&env, &Self::admin(&env), symbol_short!("withdraw"), &to);
-    }
-
-    /// Placeholder privileged rate update hook guarded by admin auth.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "role_chg")` with operation `"rate"` and target `admin`.
-    pub fn update_rate(env: Env, _rate: u32) {
-        Self::require_admin(&env);
-        let admin = Self::admin(&env);
-        emit_role_changed(&env, &admin, symbol_short!("rate"), &admin);
-    }
-
-    /// Placeholder pause hook guarded by admin auth.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "role_chg")` with operation `"pause"` and target `admin`.
-    pub fn pause(env: Env) {
-        Self::require_admin(&env);
-        let admin = Self::admin(&env);
-        emit_role_changed(&env, &admin, symbol_short!("pause"), &admin);
     }
 
     // ── Read-only ─────────────────────────────────────────────────────────────
@@ -349,6 +228,49 @@ impl AdminRolesContract {
 
     pub fn get_signers(env: Env) -> Vec<Address> {
         env.storage().instance().get(&DataKey::Signers).unwrap_or(vec![&env])
+    }
+
+    // ── Upgrade (M-of-N multisig) ─────────────────────────────────────────────
+
+    /// Approve upgrading to `new_wasm_hash`. The upgrade executes once the
+    /// number of distinct signer approvals reaches the threshold.
+    ///
+    /// Emits `("upgraded",)` with data `new_wasm_hash` when the upgrade executes.
+    pub fn approve_upgrade(env: Env, signer: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        signer.require_auth();
+        let signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(Error::NotInitialized)?;
+        if !signers.contains(&signer) {
+            return Err(Error::NotSigner);
+        }
+
+        let key = DataKey::UpgradeApprovals(new_wasm_hash.clone());
+        let mut approvals: Vec<Address> =
+            env.storage().instance().get(&key).unwrap_or(vec![&env]);
+        if approvals.contains(&signer) {
+            return Err(Error::AlreadyApproved);
+        }
+        approvals.push_back(signer);
+
+        if approvals.len() >= Self::get_threshold(env.clone()) {
+            env.storage().instance().remove(&key);
+            env.events()
+                .publish((symbol_short!("upgraded"),), new_wasm_hash.clone());
+            env.deployer().update_current_contract_wasm(new_wasm_hash);
+        } else {
+            env.storage().instance().set(&key, &approvals);
+        }
+        Ok(())
+    }
+
+    pub fn get_upgrade_approvals(env: Env, new_wasm_hash: BytesN<32>) -> u32 {
+        env.storage()
+            .instance()
+            .get::<_, Vec<Address>>(&DataKey::UpgradeApprovals(new_wasm_hash))
+            .map_or(0, |approvals| approvals.len())
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────
@@ -378,335 +300,64 @@ impl AdminRolesContract {
         }
         Ok(())
     }
-
-    /// Placeholder — in real cross-contract calls the caller is passed explicitly.
-    /// Used only by `update_threshold` which is owner-gated anyway.
-    fn caller_from_auth(env: &Env) -> Address {
-        Self::owner(env)
-    }
-
-    // ── Upgrade (M-of-N multisig) ─────────────────────────────────────────────
-
-    /// Approve a pending WASM upgrade. Executes when threshold is reached.
-    ///
-    /// Uses the same signer set and threshold configured at initialization.
-    ///
-    /// # Events
-    /// Emits `("adm_roles", "upgraded")` with `(schema_version, new_wasm_hash)` when threshold is met.
-    ///
-    /// # Panics
-    /// - `"not an authorized signer"` if `signer` is not in the signer set.
-    /// - `"already approved"` if `signer` has already approved this hash.
-    pub fn approve_upgrade(env: Env, signer: Address, new_wasm_hash: BytesN<32>) {
-        signer.require_auth();
-
-        let signers: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Signers)
-            .expect("not initialized");
-        let is_authorized = signers.iter().any(|s| s == signer);
-        assert!(is_authorized, "not an authorized signer");
-
-        let approval_key = DataKey::UpgradeApprovals(new_wasm_hash.clone());
-        let mut approvals: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&approval_key)
-            .unwrap_or(Vec::new(&env));
-
-        let already_approved = approvals.iter().any(|a| a == signer);
-        assert!(!already_approved, "already approved");
-
-        approvals.push_back(signer);
-        env.storage().instance().set(&approval_key, &approvals);
-
-        let threshold: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::Threshold)
-            .unwrap_or(1);
-
-        if approvals.len() >= threshold {
-            env.storage().instance().remove(&approval_key);
-            emit_contract_upgraded(&env, &new_wasm_hash);
-            env.deployer().update_current_contract_wasm(new_wasm_hash);
-        }
-    }
-
-    pub fn get_upgrade_approvals(env: Env, new_wasm_hash: BytesN<32>) -> u32 {
-        let approval_key = DataKey::UpgradeApprovals(new_wasm_hash);
-        let approvals: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&approval_key)
-            .unwrap_or(Vec::new(&env));
-        approvals.len()
-    }
 }
 
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
+// RBAC behaviour is covered by tests/admin_tests.rs; these cover the
+// owner-gated multisig settings and the upgrade path.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, vec, Env};
-    use soroban_sdk::{
-        testutils::{Address as _, Events},
-        vec, BytesN, Env,
-    };
 
-    fn setup() -> (Env, Address, AdminRolesContractClient<'static>) {
+    fn setup_two_signers() -> (Env, Address, Address, AdminRolesContractClient<'static>) {
         let env = Env::default();
         env.mock_all_auths();
         let id = env.register(AdminRolesContract, ());
         let client = AdminRolesContractClient::new(&env, &id);
-        let owner = Address::generate(&env);
-        client.initialize(&owner, &vec![&env], &1).unwrap();
-        (env, owner, client)
-        let contract_id = env.register(AdminRolesContract, ());
-        let client = AdminRolesContractClient::new(&env, &contract_id);
-        let admin = Address::generate(&env);
-        client.initialize(&admin, &vec![&env, admin.clone()], &1);
-        (env, admin, client)
-    }
-
-    // ── initialize ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_initialize_grants_admin_role() {
-        let (env, owner, client) = setup();
-        assert!(client.has_role(&owner, &Role::Admin));
+        let s1 = Address::generate(&env);
+        let s2 = Address::generate(&env);
+        client.initialize(&s1, &vec![&env, s1.clone(), s2.clone()], &2);
+        (env, s1, s2, client)
     }
 
     #[test]
-    fn test_double_initialize_rejected() {
-        let (env, owner, client) = setup();
-        let err = client.try_initialize(&owner, &vec![&env], &1).unwrap_err().unwrap();
-        assert_eq!(err, Error::AlreadyInitialized);
-    fn test_single_admin_auth() {
-        let (_env, admin, client) = setup();
-        client.mint(&admin, &100);
-        client.pause();
-        client.update_rate(&5);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_unauthorised_call_rejected() {
+    fn test_update_threshold_requires_owner_auth() {
         let env = Env::default();
-        let contract_id = env.register(AdminRolesContract, ());
-        let client = AdminRolesContractClient::new(&env, &contract_id);
-        let admin = Address::generate(&env);
-        env.mock_all_auths();
-        client.initialize(&admin, &vec![&env], &1);
-        let env2 = Env::default();
-        let client2 = AdminRolesContractClient::new(&env2, &contract_id);
-        client2.pause();
+        let id = env.register(AdminRolesContract, ());
+        let client = AdminRolesContractClient::new(&env, &id);
+        let owner = Address::generate(&env);
+        client.initialize(&owner, &vec![&env], &1);
+        // No auths mocked: the owner has not signed, so the call must fail.
+        assert!(client.try_update_threshold(&2).is_err());
+        assert_eq!(client.get_threshold(), 1);
     }
-
-    // ── grant_role / revoke_role ──────────────────────────────────────────────
-
-    #[test]
-    fn test_grant_and_revoke_merchant() {
-        let (env, _owner, client) = setup();
-        let merchant = Address::generate(&env);
-
-        client.grant_role(&merchant, &Role::Merchant).unwrap();
-        assert!(client.has_role(&merchant, &Role::Merchant));
-
-        client.revoke_role(&merchant, &Role::Merchant).unwrap();
-        assert!(!client.has_role(&merchant, &Role::Merchant));
-    }
-
-    #[test]
-    fn test_grant_and_revoke_operator() {
-        let (env, _owner, client) = setup();
-        let op = Address::generate(&env);
-
-        client.grant_role(&op, &Role::Operator).unwrap();
-        assert!(client.has_role(&op, &Role::Operator));
-
-        client.revoke_role(&op, &Role::Operator).unwrap();
-        assert!(!client.has_role(&op, &Role::Operator));
-        client.propose_admin(&new_admin);
-        assert!(env.events().all().len() >= 1);
-
-        client.accept_admin();
-        assert!(env.events().all().len() >= 1);
-    }
-
-    #[test]
-    fn test_grant_emits_event() {
-        let (env, _owner, client) = setup();
-        let account = Address::generate(&env);
-        client.grant_role(&account, &Role::Merchant).unwrap();
-        assert!(!env.events().all().is_empty());
-    }
-
-    #[test]
-    fn test_revoke_emits_event() {
-        let (env, _owner, client) = setup();
-        let account = Address::generate(&env);
-        client.grant_role(&account, &Role::Operator).unwrap();
-        client.revoke_role(&account, &Role::Operator).unwrap();
-        assert!(env.events().all().len() >= 2);
-    }
-
-    // ── Privileged functions: unauthorized access ─────────────────────────────
-
-    #[test]
-    fn test_mint_requires_admin_role() {
-        let (env, _owner, client) = setup();
-        let non_admin = Address::generate(&env);
-        let target = Address::generate(&env);
-        // non_admin has no Admin role
-        let err = client.try_mint(&non_admin, &target, &100).unwrap_err().unwrap();
-        assert_eq!(err, Error::Unauthorized);
-    }
-
-    #[test]
-    fn test_withdraw_requires_operator_role() {
-        let (env, _owner, client) = setup();
-        let non_op = Address::generate(&env);
-        let target = Address::generate(&env);
-        let err = client.try_withdraw(&non_op, &target, &100).unwrap_err().unwrap();
-        assert_eq!(err, Error::Unauthorized);
-    }
-
-    #[test]
-    fn test_update_rate_requires_merchant_role() {
-        let (env, _owner, client) = setup();
-        let non_merchant = Address::generate(&env);
-        let err = client.try_update_rate(&non_merchant, &10).unwrap_err().unwrap();
-        assert_eq!(err, Error::Unauthorized);
-    }
-
-    #[test]
-    fn test_pause_requires_operator_role() {
-        let (env, _owner, client) = setup();
-        let non_op = Address::generate(&env);
-        let err = client.try_pause(&non_op).unwrap_err().unwrap();
-        assert_eq!(err, Error::Unauthorized);
-    }
-
-    #[test]
-    fn test_update_signers_requires_admin_role() {
-        let (env, _owner, client) = setup();
-        let non_admin = Address::generate(&env);
-        let err = client.try_update_signers(&non_admin, &vec![&env]).unwrap_err().unwrap();
-        assert_eq!(err, Error::Unauthorized);
-    }
-
-    // ── Privileged functions: authorized access ───────────────────────────────
-
-    #[test]
-    fn test_mint_succeeds_with_admin_role() {
-        let (env, owner, client) = setup();
-        let target = Address::generate(&env);
-        client.mint(&owner, &target, &100).unwrap();
-    }
-
-    #[test]
-    fn test_withdraw_succeeds_with_operator_role() {
-        let (env, _owner, client) = setup();
-        let op = Address::generate(&env);
-        let target = Address::generate(&env);
-        client.grant_role(&op, &Role::Operator).unwrap();
-        client.withdraw(&op, &target, &50).unwrap();
-    }
-
-    #[test]
-    fn test_update_rate_succeeds_with_merchant_role() {
-        let (env, _owner, client) = setup();
-        let merchant = Address::generate(&env);
-        client.grant_role(&merchant, &Role::Merchant).unwrap();
-        client.update_rate(&merchant, &5).unwrap();
-    }
-
-    #[test]
-    fn test_pause_succeeds_with_operator_role() {
-        let (env, _owner, client) = setup();
-        let op = Address::generate(&env);
-        client.grant_role(&op, &Role::Operator).unwrap();
-        client.pause(&op).unwrap();
-    }
-
-    // ── Two-step owner transfer ───────────────────────────────────────────────
-
-    #[test]
-    fn test_two_step_transfer() {
-        let (env, _owner, client) = setup();
-        let new_owner = Address::generate(&env);
-        client.propose_admin(&new_owner).unwrap();
-        assert_eq!(client.get_pending_admin(), Some(new_owner.clone()));
-        client.accept_admin().unwrap();
-        assert_eq!(client.get_admin(), new_owner);
-        assert_eq!(client.get_pending_admin(), None);
-        // new owner gets Admin role
-        assert!(client.has_role(&new_owner, &Role::Admin));
-    }
-
-    #[test]
-    fn test_accept_without_proposal_rejected() {
-        let (_env, _owner, client) = setup();
-        let err = client.try_accept_admin().unwrap_err().unwrap();
-        assert_eq!(err, Error::NoPendingAdmin);
-    #[should_panic(expected = "already initialised")]
-    fn test_reinitialize_is_blocked() {
-        let (env, admin, client) = setup();
-        client.initialize(&admin, &vec![&env], &1);
-    }
-
-    // ── Upgrade tests ─────────────────────────────────────────────────────────
 
     #[test]
     fn test_upgrade_approval_accumulates() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(AdminRolesContract, ());
-        let client = AdminRolesContractClient::new(&env, &contract_id);
-        let s1 = Address::generate(&env);
-        let s2 = Address::generate(&env);
-        client.initialize(&s1, &vec![&env, s1.clone(), s2.clone()], &2);
-
-        let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
-        client.approve_upgrade(&s1, &fake_hash);
-        assert_eq!(client.get_upgrade_approvals(&fake_hash), 1);
+        let (env, s1, _s2, client) = setup_two_signers();
+        let hash = BytesN::from_array(&env, &[0u8; 32]);
+        client.approve_upgrade(&s1, &hash);
+        assert_eq!(client.get_upgrade_approvals(&hash), 1);
     }
 
     #[test]
-    #[should_panic(expected = "not an authorized signer")]
-    fn test_unauthorized_upgrade_rejected() {
-        let (env, _admin, client) = setup();
+    fn test_non_signer_upgrade_rejected() {
+        let (env, _s1, _s2, client) = setup_two_signers();
         let outsider = Address::generate(&env);
-        let fake_hash = BytesN::from_array(&env, &[1u8; 32]);
-        client.approve_upgrade(&outsider, &fake_hash);
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let err = client.try_approve_upgrade(&outsider, &hash).unwrap_err().unwrap();
+        assert_eq!(err, Error::NotSigner);
     }
 
     #[test]
-    #[should_panic(expected = "already approved")]
-    fn test_duplicate_approval_rejected() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(AdminRolesContract, ());
-        let client = AdminRolesContractClient::new(&env, &contract_id);
-        let s1 = Address::generate(&env);
-        let s2 = Address::generate(&env);
-        client.initialize(&s1, &vec![&env, s1.clone(), s2.clone()], &2);
-
-        let fake_hash = BytesN::from_array(&env, &[2u8; 32]);
-        client.approve_upgrade(&s1, &fake_hash);
-        client.approve_upgrade(&s1, &fake_hash);
-    }
-
-    #[test]
-    fn test_role_change_events_emitted() {
-        let (env, admin, client) = setup();
-        let target = Address::generate(&env);
-        client.mint(&target, &500);
-        client.withdraw(&target, &100);
-        // Each privileged call emits a role_chg event
-        assert!(env.events().all().len() >= 2);
+    fn test_duplicate_upgrade_approval_rejected() {
+        let (env, s1, _s2, client) = setup_two_signers();
+        let hash = BytesN::from_array(&env, &[2u8; 32]);
+        client.approve_upgrade(&s1, &hash);
+        let err = client.try_approve_upgrade(&s1, &hash).unwrap_err().unwrap();
+        assert_eq!(err, Error::AlreadyApproved);
     }
 }

--- a/contracts/admin_roles/tests/admin_tests.rs
+++ b/contracts/admin_roles/tests/admin_tests.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use admin_roles::{AdminRolesContract, AdminRolesContractClient, Error, Role};
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    vec, Address, Env,
+};
 
 fn setup() -> (Env, Address, AdminRolesContractClient<'static>) {
     let env = Env::default();
@@ -9,7 +12,7 @@ fn setup() -> (Env, Address, AdminRolesContractClient<'static>) {
     let id = env.register(AdminRolesContract, ());
     let client = AdminRolesContractClient::new(&env, &id);
     let owner = Address::generate(&env);
-    client.initialize(&owner, &vec![&env], &1).unwrap();
+    client.initialize(&owner, &vec![&env], &1);
     (env, owner, client)
 }
 
@@ -17,7 +20,7 @@ fn setup() -> (Env, Address, AdminRolesContractClient<'static>) {
 
 #[test]
 fn initialize_sets_owner_and_threshold() {
-    let (env, owner, client) = setup();
+    let (_env, owner, client) = setup();
     assert_eq!(client.get_admin(), owner);
     assert_eq!(client.get_threshold(), 1);
     assert!(client.has_role(&owner, &Role::Admin));
@@ -36,7 +39,7 @@ fn initialize_twice_returns_error() {
 fn grant_merchant_role() {
     let (env, _owner, client) = setup();
     let merchant = Address::generate(&env);
-    client.grant_role(&merchant, &Role::Merchant).unwrap();
+    client.grant_role(&merchant, &Role::Merchant);
     assert!(client.has_role(&merchant, &Role::Merchant));
 }
 
@@ -44,8 +47,8 @@ fn grant_merchant_role() {
 fn revoke_merchant_role() {
     let (env, _owner, client) = setup();
     let merchant = Address::generate(&env);
-    client.grant_role(&merchant, &Role::Merchant).unwrap();
-    client.revoke_role(&merchant, &Role::Merchant).unwrap();
+    client.grant_role(&merchant, &Role::Merchant);
+    client.revoke_role(&merchant, &Role::Merchant);
     assert!(!client.has_role(&merchant, &Role::Merchant));
 }
 
@@ -53,7 +56,7 @@ fn revoke_merchant_role() {
 fn grant_operator_role() {
     let (env, _owner, client) = setup();
     let op = Address::generate(&env);
-    client.grant_role(&op, &Role::Operator).unwrap();
+    client.grant_role(&op, &Role::Operator);
     assert!(client.has_role(&op, &Role::Operator));
 }
 
@@ -108,7 +111,7 @@ fn grant_role_by_non_owner_rejected() {
     // the owner check uses require_owner which checks the stored owner.
     // We verify the happy path here since mock_all_auths is active.
     let account = Address::generate(&env);
-    client.grant_role(&account, &Role::Admin).unwrap();
+    client.grant_role(&account, &Role::Admin);
     assert!(client.has_role(&account, &Role::Admin));
 }
 
@@ -118,7 +121,7 @@ fn grant_role_by_non_owner_rejected() {
 fn mint_with_admin_role_succeeds() {
     let (env, owner, client) = setup();
     let target = Address::generate(&env);
-    client.mint(&owner, &target, &500).unwrap();
+    client.mint(&owner, &target, &500);
 }
 
 #[test]
@@ -126,24 +129,24 @@ fn withdraw_with_operator_role_succeeds() {
     let (env, _owner, client) = setup();
     let op = Address::generate(&env);
     let target = Address::generate(&env);
-    client.grant_role(&op, &Role::Operator).unwrap();
-    client.withdraw(&op, &target, &200).unwrap();
+    client.grant_role(&op, &Role::Operator);
+    client.withdraw(&op, &target, &200);
 }
 
 #[test]
 fn update_rate_with_merchant_role_succeeds() {
     let (env, _owner, client) = setup();
     let merchant = Address::generate(&env);
-    client.grant_role(&merchant, &Role::Merchant).unwrap();
-    client.update_rate(&merchant, &15).unwrap();
+    client.grant_role(&merchant, &Role::Merchant);
+    client.update_rate(&merchant, &15);
 }
 
 #[test]
 fn pause_with_operator_role_succeeds() {
     let (env, _owner, client) = setup();
     let op = Address::generate(&env);
-    client.grant_role(&op, &Role::Operator).unwrap();
-    client.pause(&op).unwrap();
+    client.grant_role(&op, &Role::Operator);
+    client.pause(&op);
 }
 
 // ── Two-step transfer ─────────────────────────────────────────────────────────
@@ -152,8 +155,8 @@ fn pause_with_operator_role_succeeds() {
 fn two_step_transfer_works() {
     let (env, _owner, client) = setup();
     let new_owner = Address::generate(&env);
-    client.propose_admin(&new_owner).unwrap();
-    client.accept_admin().unwrap();
+    client.propose_admin(&new_owner);
+    client.accept_admin();
     assert_eq!(client.get_admin(), new_owner);
     assert!(client.has_role(&new_owner, &Role::Admin));
 }
@@ -171,15 +174,16 @@ fn accept_without_proposal_rejected() {
 fn role_granted_event_emitted() {
     let (env, _owner, client) = setup();
     let account = Address::generate(&env);
-    client.grant_role(&account, &Role::Merchant).unwrap();
-    assert!(!env.events().all().is_empty());
+    client.grant_role(&account, &Role::Merchant);
+    assert!(!env.events().all().events().is_empty());
 }
 
 #[test]
 fn role_revoked_event_emitted() {
     let (env, _owner, client) = setup();
     let account = Address::generate(&env);
-    client.grant_role(&account, &Role::Operator).unwrap();
-    client.revoke_role(&account, &Role::Operator).unwrap();
-    assert!(env.events().all().len() >= 2);
+    client.grant_role(&account, &Role::Operator);
+    client.revoke_role(&account, &Role::Operator);
+    // events().all() only holds the last invocation's events, i.e. the revoke.
+    assert!(!env.events().all().events().is_empty());
 }

--- a/contracts/integration_tests/Cargo.toml
+++ b/contracts/integration_tests/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["cdylib", "rlib"]
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 nova-rewards = { path = "../nova-rewards" }
+admin_roles = { path = "../admin_roles" }
+referral = { path = "../referral" }
+vesting = { path = "../vesting" }
 nova_token = { path = "../nova_token" }
 escrow = { path = "../escrow" }
 reward_pool = { path = "../reward_pool" }

--- a/contracts/integration_tests/tests/integration_test.rs
+++ b/contracts/integration_tests/tests/integration_test.rs
@@ -15,7 +15,7 @@ use soroban_sdk::{
     vec, Address, Env,
 };
 
-use admin_roles::{AdminRolesContract, AdminRolesContractClient};
+use admin_roles::{AdminRolesContract, AdminRolesContractClient, Error as AdminRolesError};
 use nova_token::{NovaToken, NovaTokenClient};
 use referral::{ReferralContract, ReferralContractClient};
 use reward_pool::{RewardPool, RewardPoolClient};
@@ -189,7 +189,7 @@ fn test_admin_multisig_config() {
     let s1 = Address::generate(&s.env);
     let s2 = Address::generate(&s.env);
 
-    s.admin_roles.update_signers(&vec![&s.env, s1, s2]);
+    s.admin_roles.update_signers(&s.admin, &vec![&s.env, s1, s2]);
     s.admin_roles.update_threshold(&2);
 
     assert_eq!(s.admin_roles.get_threshold(), 2);
@@ -303,11 +303,15 @@ fn test_pool_double_init_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "already initialised")]
 fn test_admin_roles_double_init_rejected() {
     let s = setup();
     let other = Address::generate(&s.env);
-    s.admin_roles.initialize(&other, &vec![&s.env], &1);
+    let err = s
+        .admin_roles
+        .try_initialize(&other, &vec![&s.env], &1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, AdminRolesError::AlreadyInitialized);
 }
 
 #[test]


### PR DESCRIPTION
Closes #1299

## State on `main`
`contracts/admin_roles/src/lib.rs` is still the 712-line merge of `a28c908` (RBAC) and `0a49a8d` (single-admin + M-of-N upgrade). It has duplicate `propose_admin`/`mint`/`update_signers`/…, and on the current `main` the crate does not even parse:

```
error: this file contains an unclosed delimiter
   --> admin_roles\src\lib.rs:712:3
```

## Decision: RBAC (spec A) is canonical
- It is the newer of the two branches, and `tests/admin_tests.rs` already specifies it.
- The only thing spec B had that A lacked was the **M-of-N WASM upgrade** that other contracts also use. I ported it: `approve_upgrade` / `get_upgrade_approvals`, now returning typed `Error::NotSigner` / `Error::AlreadyApproved` so it matches the RBAC error style.

## Security fix found along the way
In `a28c908`, `update_threshold` checked the Admin role against `caller_from_auth()`, a placeholder that just **returned the stored owner without `require_auth`**. So any account could change the multisig threshold. It now goes through `require_owner`, with a regression test that runs without `mock_all_auths` and asserts the call fails and the threshold stays unchanged.

## Test suites
- **`admin_tests.rs`**: removed `.unwrap()` on non-`try_` client calls (they return `()`, so this never compiled), added the `testutils::Events` import, and changed the revoke-event assertion. In SDK 27, `events().all()` only holds the last invocation's events.
- **`integration_test.rs`** (the three admin tests): `update_signers(&s.admin, …)`, and double-init now asserts `Error::AlreadyInitialized` via `try_initialize` instead of `should_panic("already initialised")`.
- **`integration_tests/Cargo.toml`**: added `admin_roles`, `referral`, and `vesting`. The tests import all three, but none were declared.

## Verification
```
cargo test -p admin_roles
test result: ok. 4 passed   (lib: threshold auth + upgrade)
test result: ok. 19 passed  (tests/admin_tests.rs)
```
The `integration_tests` crate still can't compile, for reasons outside this PR: `distribution/src/lib.rs` has the same bad-merge corruption (`unclosed delimiter` at 842, see #1303), and the crate's `[lib]` is missing a `panic_handler`. To check the admin changes anyway, I copied the three updated admin tests verbatim into a throwaway test in `admin_roles` with the same setup: **3 passed**. The throwaway file is not part of this PR.

## Follow-up (not changed here)
`accept_admin` gives the new owner `Role::Admin`, but the previous owner keeps theirs. Whether a transfer should revoke the old owner's role is a product call, so I left the current behaviour alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtCa64UAuavyQqEC8GgNKE